### PR TITLE
[페이지] : 체험 상세 예약 기능 작업

### DIFF
--- a/app/activities/[id]/page.tsx
+++ b/app/activities/[id]/page.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useState} from 'react';
 import Image from 'next/image';
 import {useQuery} from 'react-query';
 import {StaticImport} from 'next/dist/shared/lib/get-img-props';
-import {notFound, useParams} from 'next/navigation';
+import {notFound, useParams, useRouter} from 'next/navigation';
 import {ActivitiesInfoType} from '@/types/activities-info';
 import {getActivitiesInfo} from '@/service/api/activities/getActivitiesInfo';
 import Reservation from '@/components/activities/side-reservation';
@@ -49,19 +49,22 @@ const BannerFromDivceType = ({device, bannerImg, subImages}: BannerType) => {
   }
 };
 
-const ActivitiesUpdateModal = ({id}: {id: number}) => {
-  const sessionID = sessionStorage.getItem('id');
-  const updateAuth = sessionID && +sessionID === id;
+const ActivitiesUpdateModal = ({userId}: {userId: number}) => {
+  const sessionID = sessionStorage.getItem('userInfo');
+  const updateAuth = sessionID && JSON.parse(sessionID).id === userId;
   const [isOpenDropbox, setIsOpenDropbox] = useState<boolean>(false);
 
+  const router = useRouter();
   const handleActivitiesUpdate = (type: string) => {
     setIsOpenDropbox(false);
+    // mypage에서 병렬 라우팅 작업 완료시 해당 링크로 이동시켜줘야합니다.
     console.log(type);
+    router.push('/mypage');
   };
 
   return (
     updateAuth && (
-      <>
+      <div>
         <Image src={IconMeatball} onClick={() => setIsOpenDropbox(true)} width={40} height={40} alt="자세히보기" priority />;
         {isOpenDropbox && (
           <Dropbox
@@ -71,7 +74,7 @@ const ActivitiesUpdateModal = ({id}: {id: number}) => {
             items={DropboxItems}
           />
         )}
-      </>
+      </div>
     )
   );
 };
@@ -104,7 +107,7 @@ export default function Page() {
           <div className="flex-row items-center gap-16pxr p-0 text-xl font-bold text-nomad-black tablet:text-3xl pc:text-3xl">
             {activitiesInfo.title}
           </div>
-          <ActivitiesUpdateModal id={activitiesInfo.id} />
+          <ActivitiesUpdateModal userId={activitiesInfo.userId} />
         </div>
         <div className="flex flex-row gap-6pxr tablet:mb-25pxr pc:mb-25pxr">
           <Image src={Star} alt="별점 이미지" width={16} height={16} priority />

--- a/components/activities/side-reservation.tsx
+++ b/components/activities/side-reservation.tsx
@@ -25,7 +25,14 @@ const Reservation = ({device, pageID, price}: {device: string; pageID: string; p
 
   const mutation = useMutation(postReservation, {
     onSuccess: () => {
-      alert('데이터가 성공적으로 저장되었습니다.');
+      alert('체험 예약을 완료했습니다.');
+    },
+    onError: (error: unknown) => {
+      if (error instanceof Error) {
+        alert(error.message);
+      } else {
+        alert('알 수 없는 오류가 발생했습니다.');
+      }
     },
   });
 
@@ -60,7 +67,7 @@ const ReservationWindowsType = ({pageID, person, price, mutate, updatePerson}: R
 
   const handleSaveReservation = () => {
     if (!reservationInfo) return alert('예약 정보가 없습니다.');
-    mutate({pageID: pageID, body: {scheduleId: reservationInfo.id, headCount: person}});
+    mutate({pageID: pageID, body: {scheduleId: +reservationInfo.id, headCount: person}});
   };
 
   return (
@@ -68,7 +75,7 @@ const ReservationWindowsType = ({pageID, person, price, mutate, updatePerson}: R
       <div className="mb-16pxr">
         <div className="flex w-auto flex-row gap-3">
           <p className="mb-16pxr text-3xl font-bold text-black-100">{`₩ ${FormatNumberWithCommas(price)}`}</p>
-          <p className="mb-16pxr text-2xl font-normal leading-10 text-gray-800">{`${person}/ 인`}</p>
+          <p className="mb-16pxr text-2xl font-normal leading-10 text-gray-800">{`/ ${person}인`}</p>
         </div>
         <hr />
       </div>
@@ -136,7 +143,7 @@ const ReservationTabletType = ({pageID, person, price, mutate, updatePerson}: Re
       <div className="mb-16pxr">
         <div className="flex w-auto flex-row gap-3">
           <p className="mb-16pxr text-2xl font-bold text-black-100">{`₩ ${FormatNumberWithCommas(price)}`}</p>
-          <p className="mb-16pxr text-2xl font-normal leading-8 text-gray-800">{`${person}/ 인`}</p>
+          <p className="mb-16pxr text-2xl font-normal leading-8 text-gray-800">{`/ ${person}인`}</p>
         </div>
         <hr />
       </div>
@@ -238,7 +245,7 @@ const ReservationMobileType = ({pageID, person, price, mutate, updatePerson}: Re
           <div className="flex flex-col items-start">
             <div className="flex h-35pxr w-auto flex-row gap-3">
               <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price)}`}</p>
-              <p className="mb-16pxr text-xl font-normal leading-8 text-gray-800">{`${person}/ 인`}</p>
+              <p className="mb-16pxr text-xl font-normal leading-8 text-gray-800">{`/ ${person}인`}</p>
             </div>
             <Button className="border-0 bg-white text-lg font-semibold text-primary" onClick={() => handleOpenModal(true)}>
               <ins>날짜 선택하기</ins>

--- a/components/activities/side-reservation.tsx
+++ b/components/activities/side-reservation.tsx
@@ -285,7 +285,7 @@ const ReservationMobileType = ({pageID, price, state, dispatch, updateSchedule, 
         <div className="flex flex-row flex-wrap justify-between px-18pxr py-18pxr">
           <div className="flex flex-col items-start">
             <div className="flex h-35pxr w-auto flex-row gap-3">
-              <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price)}`}</p>
+              <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * state.person)}`}</p>
               <p className="mb-16pxr text-xl font-normal leading-8 text-gray-800">{`/ ${state.person}인`}</p>
             </div>
             <Button className="border-0 bg-white text-lg font-semibold text-primary" onClick={() => handleOpenScheduleModal(true)}>
@@ -312,7 +312,7 @@ const ReservationMobileType = ({pageID, price, state, dispatch, updateSchedule, 
                 <Image src={Cancle} width={40} height={40} alt="cancle" />
               </Button>
             </div>
-            <SmCalendar pageID={pageID} device={'mobile'}state={state} dispatch={dispatch} onSelect={updateSchedule} />
+            <SmCalendar pageID={pageID} device={'mobile'} state={state} dispatch={dispatch} onSelect={updateSchedule} />
             <Button
               className={`absolute bottom-40pxr left-24pxr flex h-56pxr min-w-327pxr flex-row items-center justify-center rounded-md ${!state.schedule?.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
               disabled={!state.schedule.id}

--- a/components/activities/side-reservation.tsx
+++ b/components/activities/side-reservation.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useReducer} from 'react';
 import Image from 'next/image';
 import SmCalendar from '@/components/activities/sm-calendar';
 import Button from '@/components/common/button';
@@ -7,21 +7,56 @@ import OverlayContainer from '@/components/common/modal/overlay-container';
 import Plus from '@/public/icon/icon_plus.png';
 import Minus from '@/public/icon/icon_minus.png';
 import Cancle from '@/public/icon/icon_cancle.png';
-import {ReservationPost, SchedulesDateType} from '@/types/activities-info';
+import {ReservationInfoType, SchedulesDateType, SchedulesType} from '@/types/activities-info';
 import FormatNumberWithCommas from '@/utils/format-number';
 import {useMutation} from 'react-query';
 import postReservation from '@/service/api/activities/postActivities';
+import dayjs from 'dayjs';
+
+const initialState: ReservationInfoType = {
+  person: 1,
+  scheduleModal: false,
+  personModal: false,
+  schedule: {date: '', startTime: '', endTime: '', id: 0},
+  daySchedule: {date: dayjs().format('YYYY-MM-DD'), times: []},
+};
+
+type Action =
+  | {type: 'SET_PERSON'; payload: number}
+  | {type: 'SET_SCHEDULE_MODAL'; payload: boolean}
+  | {type: 'SET_PERSON_MODAL'; payload: boolean}
+  | {type: 'SET_SCHEDULE'; payload: SchedulesDateType}
+  | {type: 'SET_DAY_SCHEDULE'; payload: SchedulesType};
 
 interface ReservationProps {
   pageID: string;
-  person: number;
   price: number;
-  mutate: (data: {pageID: string; body: ReservationPost}) => void;
+  state: ReservationInfoType;
+  dispatch: React.Dispatch<Action>;
   updatePerson: (count: number) => void;
+  updateSchedule: (schedule: SchedulesDateType) => void;
+  saveReservation: () => void;
 }
 
+const reservationReducer: (state: ReservationInfoType, action: Action) => ReservationInfoType = (state, action) => {
+  switch (action.type) {
+    case 'SET_PERSON':
+      return {...state, person: action.payload};
+    case 'SET_SCHEDULE_MODAL':
+      return {...state, scheduleModal: action.payload};
+    case 'SET_PERSON_MODAL':
+      return {...state, personModal: action.payload};
+    case 'SET_SCHEDULE':
+      return {...state, schedule: action.payload};
+    case 'SET_DAY_SCHEDULE':
+      return {...state, daySchedule: action.payload};
+    default:
+      return state;
+  }
+};
+
 const Reservation = ({device, pageID, price}: {device: string; pageID: string; price: number}) => {
-  const [person, setPerson] = useState<number>(1);
+  const [state, dispatch] = useReducer(reservationReducer, initialState);
 
   const mutation = useMutation(postReservation, {
     onSuccess: () => {
@@ -36,46 +71,72 @@ const Reservation = ({device, pageID, price}: {device: string; pageID: string; p
     },
   });
 
-  const handleUpdatePerson = useCallback(
-    (count: number) => {
-      if (person + count < 1) return alert('최소 예약 인원은 1명입니다.');
-      setPerson(person + count);
-    },
-    [person],
-  );
+  const handleSelectSchedule = (schedule: SchedulesDateType) => {
+    dispatch({type: 'SET_SCHEDULE', payload: schedule});
+  };
+
+  const handleUpdatePerson = (count: number) => {
+    const person = state.person + count;
+    if (person < 1) return alert('최소 예약 인원은 1명입니다.');
+    dispatch({type: 'SET_PERSON', payload: person});
+  };
+
+  const handleSaveReservation = () => {
+    if (!state.schedule) return alert('예약 정보가 없습니다.');
+    mutation.mutate({pageID: pageID, body: {scheduleId: state.schedule.id, headCount: state.person}});
+  };
 
   const ReservationDeviceType = ({device}: {device: string}) => {
     switch (device) {
       case 'windows':
-        return <ReservationWindowsType pageID={pageID} person={person} price={price} mutate={mutation.mutate} updatePerson={handleUpdatePerson} />;
+        return (
+          <ReservationWindowsType
+            pageID={pageID}
+            price={price}
+            state={state}
+            dispatch={dispatch}
+            updateSchedule={handleSelectSchedule}
+            updatePerson={handleUpdatePerson}
+            saveReservation={handleSaveReservation}
+          />
+        );
       case 'tablet':
-        return <ReservationTabletType pageID={pageID} person={person} price={price} mutate={mutation.mutate} updatePerson={handleUpdatePerson} />;
+        return (
+          <ReservationTabletType
+            pageID={pageID}
+            price={price}
+            state={state}
+            dispatch={dispatch}
+            updateSchedule={handleSelectSchedule}
+            updatePerson={handleUpdatePerson}
+            saveReservation={handleSaveReservation}
+          />
+        );
       default:
-        return <ReservationMobileType pageID={pageID} person={person} price={price} mutate={mutation.mutate} updatePerson={handleUpdatePerson} />;
+        return (
+          <ReservationMobileType
+            pageID={pageID}
+            price={price}
+            state={state}
+            dispatch={dispatch}
+            updateSchedule={handleSelectSchedule}
+            updatePerson={handleUpdatePerson}
+            saveReservation={handleSaveReservation}
+          />
+        );
     }
   };
 
   return <ReservationDeviceType device={device} />;
 };
 
-const ReservationWindowsType = ({pageID, person, price, mutate, updatePerson}: ReservationProps) => {
-  const [reservationInfo, setReservationInfo] = useState<SchedulesDateType>();
-
-  const handleSelectSchedule = ({date, id, startTime, endTime}: SchedulesDateType) => {
-    setReservationInfo({date, id, startTime, endTime});
-  };
-
-  const handleSaveReservation = () => {
-    if (!reservationInfo) return alert('예약 정보가 없습니다.');
-    mutate({pageID: pageID, body: {scheduleId: +reservationInfo.id, headCount: person}});
-  };
-
+const ReservationWindowsType = ({pageID, price, state, dispatch, updateSchedule, updatePerson, saveReservation}: ReservationProps) => {
   return (
     <div className="rounded-xl border border-solid border-gray-200 bg-white px-24pxr pb-18pxr pt-24pxr shadow-sidenavi-box tablet:h-full pc:min-h-748pxr pc:min-w-384pxr">
       <div className="mb-16pxr">
         <div className="flex w-auto flex-row gap-3">
           <p className="mb-16pxr text-3xl font-bold text-black-100">{`₩ ${FormatNumberWithCommas(price)}`}</p>
-          <p className="mb-16pxr text-2xl font-normal leading-10 text-gray-800">{`/ ${person}인`}</p>
+          <p className="mb-16pxr text-2xl font-normal leading-10 text-gray-800">{`/ ${state.person}인`}</p>
         </div>
         <hr />
       </div>
@@ -83,7 +144,7 @@ const ReservationWindowsType = ({pageID, person, price, mutate, updatePerson}: R
         <div className="flex w-auto flex-row gap-3">
           <p className="mb-16pxr text-xl font-bold text-nomad-black">날짜</p>
         </div>
-        <SmCalendar pageID={pageID} onSelect={handleSelectSchedule} />
+        <SmCalendar pageID={pageID} state={state} dispatch={dispatch} onSelect={updateSchedule} />
       </div>
       <hr />
       <div className="mb-24pxr mt-12pxr">
@@ -95,7 +156,7 @@ const ReservationWindowsType = ({pageID, person, price, mutate, updatePerson}: R
           >
             <Image src={Minus} width={20} height={20} alt="minus" />
           </Button>
-          <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{person}</p>
+          <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{state.person}</p>
           <Button
             className="relative h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr"
             onClick={() => updatePerson(1)}
@@ -104,9 +165,9 @@ const ReservationWindowsType = ({pageID, person, price, mutate, updatePerson}: R
           </Button>
         </div>
         <Button
-          className={`my-24pxr flex h-56pxr w-full flex-row items-center justify-center gap-4pxr rounded-s px-8pxr py-40pxr ${!reservationInfo?.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
-          disabled={!reservationInfo?.id}
-          onClick={handleSaveReservation}
+          className={`my-24pxr flex h-56pxr w-full flex-row items-center justify-center gap-4pxr rounded-s px-8pxr py-40pxr ${!state.schedule?.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
+          disabled={!state.schedule?.id}
+          onClick={saveReservation}
         >
           <p className="text-lg font-bold text-white">예약하기</p>
         </Button>
@@ -114,28 +175,15 @@ const ReservationWindowsType = ({pageID, person, price, mutate, updatePerson}: R
       <hr />
       <div className="mt-16pxr flex flex-row items-center justify-between">
         <p className="text-xl font-bold text-nomad-black">총 합계</p>
-        <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * person)}`}</p>
+        <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * state.person)}`}</p>
       </div>
     </div>
   );
 };
 
-const ReservationTabletType = ({pageID, person, price, mutate, updatePerson}: ReservationProps) => {
-  const [reservationInfo, setReservationInfo] = useState<SchedulesDateType>();
-  const [modalStatus, setModalStatus] = useState<boolean>(false);
-
-  const handleSelectSchedule = ({date, id, startTime, endTime}: SchedulesDateType) => {
-    setReservationInfo({date, id, startTime, endTime});
-  };
-
+const ReservationTabletType = ({pageID, price, state, dispatch, updateSchedule, updatePerson, saveReservation}: ReservationProps) => {
   const handleOpenModal = (status: boolean) => {
-    if (status) setReservationInfo(undefined);
-    setModalStatus(status);
-  };
-
-  const handleSaveReservation = () => {
-    if (!reservationInfo) return alert('예약 정보가 없습니다.');
-    mutate({pageID: pageID, body: {scheduleId: reservationInfo.id, headCount: person}});
+    dispatch({type: 'SET_SCHEDULE_MODAL', payload: status});
   };
 
   return (
@@ -143,7 +191,7 @@ const ReservationTabletType = ({pageID, person, price, mutate, updatePerson}: Re
       <div className="mb-16pxr">
         <div className="flex w-auto flex-row gap-3">
           <p className="mb-16pxr text-2xl font-bold text-black-100">{`₩ ${FormatNumberWithCommas(price)}`}</p>
-          <p className="mb-16pxr text-2xl font-normal leading-8 text-gray-800">{`/ ${person}인`}</p>
+          <p className="mb-16pxr text-2xl font-normal leading-8 text-gray-800">{`/ ${state.person}인`}</p>
         </div>
         <hr />
       </div>
@@ -157,8 +205,8 @@ const ReservationTabletType = ({pageID, person, price, mutate, updatePerson}: Re
         >
           날짜 선택하기
         </Button>
-        {reservationInfo?.id && (
-          <p className="text-lg font-semibold text-nomad-black">{`${reservationInfo?.date} ${reservationInfo?.startTime} ~ ${reservationInfo?.endTime}`}</p>
+        {state.schedule.date.length > 0 && (
+          <p className="text-lg font-semibold text-nomad-black">{`${state.schedule.date} ${state.schedule.startTime} ~ ${state.schedule.endTime}`}</p>
         )}
       </div>
       <hr />
@@ -171,7 +219,7 @@ const ReservationTabletType = ({pageID, person, price, mutate, updatePerson}: Re
           >
             <Image src={Minus} width={20} height={20} alt="minus" />
           </Button>
-          <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{person}</p>
+          <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{state.person}</p>
           <Button
             className="relative h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr"
             onClick={() => updatePerson(1)}
@@ -180,9 +228,9 @@ const ReservationTabletType = ({pageID, person, price, mutate, updatePerson}: Re
           </Button>
         </div>
         <Button
-          className={`my-24pxr flex h-56pxr w-full flex-row items-center justify-center gap-4pxr rounded-md px-8pxr py-40pxr ${!reservationInfo?.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
-          disabled={!reservationInfo?.id}
-          onClick={handleSaveReservation}
+          className={`my-24pxr flex h-56pxr w-full flex-row items-center justify-center gap-4pxr rounded-md px-8pxr py-40pxr ${!state.schedule.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
+          disabled={state.schedule.id === 0}
+          onClick={saveReservation}
         >
           <p className="text-lg font-bold text-white">예약하기</p>
         </Button>
@@ -190,21 +238,23 @@ const ReservationTabletType = ({pageID, person, price, mutate, updatePerson}: Re
       <hr />
       <div className="mt-16pxr flex flex-row items-center justify-between">
         <p className="text-xl font-bold text-nomad-black">총 합계</p>
-        <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * person)}`}</p>
+        <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * state.person)}`}</p>
       </div>
-      {modalStatus && (
+      {state.scheduleModal && (
         <OverlayContainer onClose={() => handleOpenModal(false)}>
-          <div onClick={e => e.stopPropagation()} className="max-h-700pxr w-480pxr rounded-3xl bg-white px-24pxr pb-32pxr pt-28pxr">
+          <div className="relative max-h-700pxr w-480pxr rounded-3xl bg-white px-24pxr pb-32pxr pt-28pxr" onClick={e => e.stopPropagation()}>
             <div className="mb-30pxr flex flex-row justify-between">
               <p className="mb-16pxr text-xl font-bold text-nomad-black">날짜</p>
               <Button onClick={() => handleOpenModal(false)}>
                 <Image src={Cancle} width={40} height={40} alt="cancle" />
               </Button>
             </div>
-            <SmCalendar pageID={pageID} onSelect={handleSelectSchedule} />
+            <div className="mb-100pxr">
+              <SmCalendar pageID={pageID} state={state} dispatch={dispatch} onSelect={updateSchedule} />
+            </div>
             <Button
-              className={`mb-10pxr flex h-56pxr w-full items-center justify-center rounded-md bg-nomad-black px-8pxr ${!reservationInfo && 'bg-gray-400'}`}
-              disabled={!reservationInfo}
+              className={`absolute bottom-32pxr left-24pxr flex h-56pxr min-w-432pxr items-center justify-center rounded-md ${!state.schedule.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
+              disabled={!state.schedule.id}
               onClick={() => handleOpenModal(false)}
             >
               <p className="text-lg font-bold text-white">확인</p>
@@ -216,27 +266,18 @@ const ReservationTabletType = ({pageID, person, price, mutate, updatePerson}: Re
   );
 };
 
-const ReservationMobileType = ({pageID, person, price, mutate, updatePerson}: ReservationProps) => {
-  const [reservationInfo, setReservationInfo] = useState<SchedulesDateType>();
-  const [modalStatus, setModalStatus] = useState<boolean>(false);
-
-  const handleSelectSchedule = ({date, id, startTime, endTime}: SchedulesDateType) => {
-    setReservationInfo({date, id, startTime, endTime});
+const ReservationMobileType = ({pageID, price, state, dispatch, updateSchedule, updatePerson, saveReservation}: ReservationProps) => {
+  const handleOpenScheduleModal = (status: boolean) => {
+    dispatch({type: 'SET_SCHEDULE_MODAL', payload: status});
+  };
+  const handleOpenPersonModal = () => {
+    dispatch({type: 'SET_SCHEDULE_MODAL', payload: false});
+    dispatch({type: 'SET_PERSON_MODAL', payload: true});
   };
 
-  const handleOpenModal = (status: boolean) => {
-    setModalStatus(status);
+  const handleClosePersonModal = (status: boolean) => {
+    dispatch({type: 'SET_PERSON_MODAL', payload: status});
   };
-
-  const handleSaveReservation = () => {
-    if (!reservationInfo) return alert('예약 정보가 없습니다.');
-    mutate({pageID: pageID, body: {scheduleId: reservationInfo.id, headCount: person}});
-  };
-
-  useEffect(() => {
-    // 임시 작업으로 추후 제거 예정
-    updatePerson(1);
-  }, [updatePerson]);
 
   return (
     <>
@@ -245,39 +286,76 @@ const ReservationMobileType = ({pageID, person, price, mutate, updatePerson}: Re
           <div className="flex flex-col items-start">
             <div className="flex h-35pxr w-auto flex-row gap-3">
               <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price)}`}</p>
-              <p className="mb-16pxr text-xl font-normal leading-8 text-gray-800">{`/ ${person}인`}</p>
+              <p className="mb-16pxr text-xl font-normal leading-8 text-gray-800">{`/ ${state.person}인`}</p>
             </div>
-            <Button className="border-0 bg-white text-lg font-semibold text-primary" onClick={() => handleOpenModal(true)}>
+            <Button className="border-0 bg-white text-lg font-semibold text-primary" onClick={() => handleOpenScheduleModal(true)}>
               <ins>날짜 선택하기</ins>
             </Button>
           </div>
           <Button
-            className={`h-48pxr min-w-106pxr items-center justify-center rounded-md bg-gray-500 text-lg font-bold text-white ${!reservationInfo && 'bg-gray-400'}`}
-            disabled={!reservationInfo}
-            onClick={handleSaveReservation}
+            className={`h-48pxr min-w-106pxr items-center justify-center rounded-md text-lg font-bold text-white ${!state.schedule.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
+            disabled={state.schedule.id === 0}
+            onClick={saveReservation}
           >
             예약하기
           </Button>
         </div>
       </div>
-      {modalStatus && (
-        <OverlayContainer onClose={() => handleOpenModal(false)}>
-          <div onClick={e => e.stopPropagation()} className="h-full min-w-373pxr bg-white px-24pxr pb-40pxr pt-24pxr">
+      {state.scheduleModal && (
+        <OverlayContainer onClose={() => handleOpenScheduleModal(false)}>
+          <div className="relative h-full w-373pxr bg-white px-24pxr pb-40pxr pt-24pxr" onClick={e => e.stopPropagation()}>
             <div className="mb-30pxr flex flex-row justify-between">
               <div className="flex flex-row gap-3">
                 <p className="text-xl font-bold text-nomad-black">날짜</p>
               </div>
-              <Button onClick={() => handleOpenModal(false)}>
+              <Button onClick={() => handleOpenScheduleModal(false)}>
                 <Image src={Cancle} width={40} height={40} alt="cancle" />
               </Button>
             </div>
-            <div className="mx-auto mb-24pxr min-w-305pxr items-center justify-center rounded-lg border border-solid border-gray-100 p-0">
-              <SmCalendar pageID={pageID} onSelect={handleSelectSchedule} />
+            <SmCalendar pageID={pageID} device={'mobile'}state={state} dispatch={dispatch} onSelect={updateSchedule} />
+            <Button
+              className={`absolute bottom-40pxr left-24pxr flex h-56pxr min-w-327pxr flex-row items-center justify-center rounded-md ${!state.schedule?.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
+              disabled={!state.schedule.id}
+              onClick={handleOpenPersonModal}
+            >
+              <p className="text-lg font-bold text-white">다음</p>
+            </Button>
+          </div>
+        </OverlayContainer>
+      )}
+      {state.personModal && (
+        <OverlayContainer onClose={() => handleClosePersonModal(false)}>
+          <div className="relative h-full min-w-373pxr bg-white px-24pxr pb-40pxr pt-24pxr" onClick={e => e.stopPropagation()}>
+            <div className="mb-30pxr flex flex-row justify-between">
+              <div className="flex flex-row gap-3">
+                <p className="text-xl font-bold text-nomad-black">날짜</p>
+              </div>
+              <Button onClick={() => handleClosePersonModal(false)}>
+                <Image src={Cancle} width={40} height={40} alt="cancle" />
+              </Button>
+            </div>
+            <div className="flex flex-col">
+              <p className="mb-24pxr">예약할 인원을 선택해주세요.</p>
+              <div className="shadow-[0px_2px_4px_rgba(5, 16, 55, 0.06)] inset-shadow-[0px_0px_0px_1px_#CDD0DC] flex h-42pxr w-120pxr flex-row items-start gap-10pxr rounded-md border bg-white p-0">
+                <Button
+                  className="relative h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr"
+                  onClick={() => updatePerson(-1)}
+                >
+                  <Image src={Minus} width={20} height={20} alt="minus" />
+                </Button>
+                <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{state.person}</p>
+                <Button
+                  className="relative h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr"
+                  onClick={() => updatePerson(1)}
+                >
+                  <Image src={Plus} width={20} height={20} alt="plus" />
+                </Button>
+              </div>
             </div>
             <Button
-              className={`min-w-432px flex h-56pxr w-full flex-row items-center justify-center gap-4pxr rounded-md bg-nomad-black ${!reservationInfo && 'bg-gray-400'}`}
-              disabled={!reservationInfo}
-              onClick={() => handleOpenModal(false)}
+              className="absolute bottom-40pxr left-24pxr flex h-56pxr min-w-327pxr flex-row items-center justify-center rounded-md bg-nomad-black"
+              disabled={!state.schedule.id}
+              onClick={() => handleClosePersonModal(false)}
             >
               <p className="text-lg font-bold text-white">확인</p>
             </Button>

--- a/components/activities/sm-calendar.tsx
+++ b/components/activities/sm-calendar.tsx
@@ -9,8 +9,10 @@ import weekOfYear from 'dayjs/plugin/weekOfYear';
 import weekYear from 'dayjs/plugin/weekYear';
 import {getActivitiesSchedule} from '@/service/api/activities/getActivitiesInfo';
 import {useQuery} from 'react-query';
-import {SchedulesDateType, SchedulesType} from '@/types/activities-info';
+import {ReservationInfoType, SchedulesDateType, SchedulesType} from '@/types/activities-info';
 import Button from '../common/button';
+
+type Action = {type: 'SET_DAY_SCHEDULE'; payload: SchedulesType};
 
 interface CalendarHeaderType {
   value: Dayjs;
@@ -18,10 +20,17 @@ interface CalendarHeaderType {
 }
 interface SmCalendarType {
   pageID: string;
+  state: ReservationInfoType;
+  device?: string;
+  dispatch: React.Dispatch<Action>;
   onSelect: ({date, id, startTime, endTime}: SchedulesDateType) => void;
 }
 
-const DefaultTime = {date: '', id: 0, startTime: '', endTime: ''};
+const defaultTime = {date: '', id: 0, startTime: '', endTime: ''};
+const defaultSchedule = {
+  date: '',
+  times: [{startTime: '', endTime: '', id: 0}],
+};
 
 const CalendarHeader = ({value, onChange}: CalendarHeaderType) => {
   const year = value.year();
@@ -50,41 +59,39 @@ const CalendarHeader = ({value, onChange}: CalendarHeaderType) => {
   );
 };
 
-const SmCalendar = ({pageID, onSelect}: SmCalendarType) => {
+const SmCalendar = ({pageID, state, device = 'order', dispatch, onSelect}: SmCalendarType) => {
   dayjs.extend(weekday);
   dayjs.extend(localeData);
   dayjs.extend(weekOfYear);
   dayjs.extend(weekYear);
-  const [selectedDay, setSelectedDay] = useState<Dayjs>(dayjs());
-  const [daySchedule, setDaySchedule] = useState<SchedulesType>({date: 'string', times: []});
-  const [selectTime, setSelectTime] = useState<SchedulesDateType>(DefaultTime);
+  const [selectDate, setSelectDate] = useState<string>(dayjs().format('YYYY-MM-DD'));
+  const [selectTime, setSelectTime] = useState<SchedulesDateType>(state.schedule);
 
   const {data: schedules} = useQuery<SchedulesType[]>({
-    queryKey: ['schedules', selectedDay],
-    queryFn: () => getActivitiesSchedule(pageID, selectedDay?.format('YYYY-MM-DD')),
+    queryKey: ['schedules', selectDate],
+    queryFn: () => getActivitiesSchedule(pageID, selectDate),
+    enabled: !!selectDate,
   });
 
-  const getScheduleMatch = useCallback(
+  const setScheduleMatch = useCallback(
     (date: Dayjs) => {
-      const getTodaySchedule = schedules?.reduce<SchedulesType>(
-        (acc, curr) => {
-          if (dayjs(curr.date).isSame(date, 'day')) {
-            acc = curr;
-          }
-          return acc;
-        },
-        {
-          date: '',
-          times: [{startTime: '', endTime: '', id: 0}],
-        },
-      );
-
-      if (!getTodaySchedule || getTodaySchedule.date.length < 1) return undefined;
+      const getTodaySchedule = schedules?.reduce<SchedulesType>((acc, curr) => {
+        if (dayjs(curr.date).isSame(date, 'day')) {
+          acc = curr;
+        }
+        return acc;
+      }, defaultSchedule);
 
       // 현재 날짜와 시간 보다 이전이라면 제거
-      return getTodaySchedule;
+      if (getTodaySchedule) {
+        if (getTodaySchedule.date.length > 0) {
+          dispatch({type: 'SET_DAY_SCHEDULE', payload: getTodaySchedule});
+        } else {
+          dispatch({type: 'SET_DAY_SCHEDULE', payload: {date: date.format('YYYY-MM-DD'), times: [{startTime: '', endTime: '', id: 0}]}});
+        }
+      }
     },
-    [schedules],
+    [dispatch, schedules],
   );
 
   const saveTime = useCallback(
@@ -95,60 +102,55 @@ const SmCalendar = ({pageID, onSelect}: SmCalendarType) => {
     [onSelect],
   );
 
-  const handleOnSelect = useCallback(
-    (date: Dayjs) => {
-      setSelectedDay(date);
-      saveTime(DefaultTime);
-      const getDatSchedule = getScheduleMatch(date);
-      if (getDatSchedule) setDaySchedule(getDatSchedule);
-    },
-    [getScheduleMatch, saveTime],
-  );
+  const handleChangeDay = (date: Dayjs) => {
+    setSelectDate(date.format('YYYY-MM-DD'));
+    setScheduleMatch(date);
+    saveTime(defaultTime);
+  };
 
-  const handleTimeClick = ({date, id, startTime, endTime}: SchedulesDateType) => {
+  const handleSelectTime = ({date, id, startTime, endTime}: SchedulesDateType) => {
     const getData = {date, id, startTime, endTime};
     saveTime(getData);
   };
 
   useEffect(() => {
-    console.log('daySchedule', daySchedule);
-
-    if (daySchedule.times.length < 1 && schedules) {
-      const getDatSchedule = getScheduleMatch(selectedDay);
-      if (getDatSchedule) setDaySchedule(getDatSchedule);
+    if (state.daySchedule.times.length < 1 && schedules) {
+      setScheduleMatch(dayjs());
     }
-  }, [daySchedule, getScheduleMatch, schedules, selectedDay]);
+  }, [schedules, setScheduleMatch, state.daySchedule.times.length]);
 
   return (
     <>
       <div className="mx-auto w-305pxr items-center justify-center rounded-lg border border-solid border-gray-100 p-0">
         <Calendar
           locale={locale}
-          value={selectedDay}
+          value={dayjs(state.daySchedule.date)}
           fullscreen={false}
           headerRender={(props: CalendarHeaderType) => <CalendarHeader {...props} />}
-          onSelect={handleOnSelect}
+          onChange={handleChangeDay}
+          onSelect={handleChangeDay}
         />
       </div>
       <div className="min-w-336pxr flex-col">
-        <p className="mt-16pxr w-full text-2lg font-bold text-nomad-black">예약 가능한 시간</p>
-        <div className="no-scrollbar mb-16pxr mt-14pxr flex h-110pxr flex-row flex-wrap gap-12pxr overflow-y-scroll">
-          <div className="mb-16pxr flex flex-row flex-wrap gap-12pxr">
-            {daySchedule &&
-              daySchedule.times.map(dt => {
-                return (
-                  <Button
-                    className={`w-130xr h-46pxr items-center justify-center rounded-lg px-10pxr py-12pxr ${selectTime.id === dt.id ? 'bg-nomad-black' : 'border border-black-50 bg-white'}`}
-                    key={dt.id}
-                    onClick={() => handleTimeClick({date: daySchedule.date, id: dt.id, startTime: dt.startTime, endTime: dt.endTime})}
-                  >
-                    <p
-                      className={`text-lg font-medium ${selectTime.id === dt.id ? 'text-white' : 'text-black-50'}`}
-                    >{`${dt.startTime} ~ ${dt.endTime}`}</p>
-                  </Button>
-                );
-              })}
-          </div>
+        <p className="mt-16pxr text-2lg font-bold text-nomad-black">예약 가능한 시간</p>
+        <div
+          className={`mt-14pxr flex flex-row flex-wrap gap-12pxr overflow-y-scroll ${state.daySchedule.times.length < 4 && 'no-scrollbar'} ${device === 'mobile' ? 'h-220pxr' : 'h-110pxr'}`}
+        >
+          {state.daySchedule.times.map(dt => {
+            return (
+              dt.id > 0 && (
+                <Button
+                  className={`w-130xr h-46pxr items-center justify-center rounded-lg px-10pxr py-12pxr ${selectTime.id === dt.id ? 'bg-nomad-black' : 'border border-black-50 bg-white'}`}
+                  key={dt.id}
+                  onClick={() => handleSelectTime({date: state.daySchedule.date, id: dt.id, startTime: dt.startTime, endTime: dt.endTime})}
+                >
+                  <p
+                    className={`text-lg font-medium ${selectTime.id === dt.id ? 'text-white' : 'text-black-50'}`}
+                  >{`${dt.startTime} ~ ${dt.endTime}`}</p>
+                </Button>
+              )
+            );
+          })}
         </div>
       </div>
     </>

--- a/components/activities/sm-calendar.tsx
+++ b/components/activities/sm-calendar.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {Dayjs} from 'dayjs';
 import dayjs from 'dayjs';
 import {Calendar} from 'antd';
@@ -113,6 +113,14 @@ const SmCalendar = ({pageID, state, device = 'order', dispatch, onSelect}: SmCal
     saveTime(getData);
   };
 
+  const checkTime = useMemo(
+    () => (hour: string) => {
+      const nowHour = +dayjs().get('hour');
+      return nowHour >= +hour.substring(0, 2);
+    },
+    [],
+  );
+
   useEffect(() => {
     if (state.daySchedule.times.length < 1 && schedules) {
       setScheduleMatch(dayjs());
@@ -132,7 +140,17 @@ const SmCalendar = ({pageID, state, device = 'order', dispatch, onSelect}: SmCal
         />
       </div>
       <div className="min-w-336pxr flex-col">
-        <p className="mt-16pxr text-2lg font-bold text-nomad-black">예약 가능한 시간</p>
+        <div className="flex flex-row gap-3">
+          <p className="mt-16pxr text-2lg font-bold text-nomad-black">예약 가능한 시간</p>
+          <div className="mt-16pxr flex flex-row gap-1">
+            <div className="m-auto h-10pxr w-10pxr border border-red-200"></div>
+            <p className="text-sm font-normal text-nomad-black">예약 불가</p>
+          </div>
+          <div className="mt-16pxr flex flex-row gap-1">
+            <div className="m-auto h-10pxr w-10pxr border border-nomad-black" />
+            <p className="text-sm font-normal text-nomad-black">예약 가능</p>
+          </div>
+        </div>
         <div
           className={`mt-14pxr flex flex-row flex-wrap gap-12pxr overflow-y-scroll ${state.daySchedule.times.length < 4 && 'no-scrollbar'} ${device === 'mobile' ? 'h-220pxr' : 'h-110pxr'}`}
         >
@@ -140,9 +158,10 @@ const SmCalendar = ({pageID, state, device = 'order', dispatch, onSelect}: SmCal
             return (
               dt.id > 0 && (
                 <Button
-                  className={`w-130xr h-46pxr items-center justify-center rounded-lg px-10pxr py-12pxr ${selectTime.id === dt.id ? 'bg-nomad-black' : 'border border-black-50 bg-white'}`}
+                  className={`w-130xr h-46pxr items-center justify-center rounded-lg px-10pxr py-12pxr ${selectTime.id === dt.id ? 'bg-nomad-black' : 'border border-black-50 bg-white'} ${checkTime(dt.startTime) && 'border border-red-200'}`}
                   key={dt.id}
                   onClick={() => handleSelectTime({date: state.daySchedule.date, id: dt.id, startTime: dt.startTime, endTime: dt.endTime})}
+                  disabled={checkTime(dt.startTime)}
                 >
                   <p
                     className={`text-lg font-medium ${selectTime.id === dt.id ? 'text-white' : 'text-black-50'}`}

--- a/components/activities/sm-calendar.tsx
+++ b/components/activities/sm-calendar.tsx
@@ -56,14 +56,12 @@ const SmCalendar = ({pageID, onSelect}: SmCalendarType) => {
   dayjs.extend(weekOfYear);
   dayjs.extend(weekYear);
   const [selectedDay, setSelectedDay] = useState<Dayjs>(dayjs());
-  const [daySchedule, setDaySchedule] = useState<SchedulesType>();
+  const [daySchedule, setDaySchedule] = useState<SchedulesType>({date: 'string', times: []});
   const [selectTime, setSelectTime] = useState<SchedulesDateType>(DefaultTime);
 
   const {data: schedules} = useQuery<SchedulesType[]>({
     queryKey: ['schedules', selectedDay],
     queryFn: () => getActivitiesSchedule(pageID, selectedDay?.format('YYYY-MM-DD')),
-    structuralSharing: false,
-    notifyOnChangeProps: ['data'],
   });
 
   const getScheduleMatch = useCallback(
@@ -101,8 +99,10 @@ const SmCalendar = ({pageID, onSelect}: SmCalendarType) => {
     (date: Dayjs) => {
       setSelectedDay(date);
       saveTime(DefaultTime);
+      const getDatSchedule = getScheduleMatch(date);
+      if (getDatSchedule) setDaySchedule(getDatSchedule);
     },
-    [saveTime],
+    [getScheduleMatch, saveTime],
   );
 
   const handleTimeClick = ({date, id, startTime, endTime}: SchedulesDateType) => {
@@ -111,10 +111,13 @@ const SmCalendar = ({pageID, onSelect}: SmCalendarType) => {
   };
 
   useEffect(() => {
-    if (schedules && selectedDay) {
-      setDaySchedule(getScheduleMatch(selectedDay));
+    console.log('daySchedule', daySchedule);
+
+    if (daySchedule.times.length < 1 && schedules) {
+      const getDatSchedule = getScheduleMatch(selectedDay);
+      if (getDatSchedule) setDaySchedule(getDatSchedule);
     }
-  }, [getScheduleMatch, schedules, selectedDay]);
+  }, [daySchedule, getScheduleMatch, schedules, selectedDay]);
 
   return (
     <>

--- a/service/api/activities/postActivities.ts
+++ b/service/api/activities/postActivities.ts
@@ -1,10 +1,23 @@
 import {ReservationPost} from '@/types/activities-info';
-import INSTANCE_URL from '../instance';
+import INSTANCE_URL from '@/service/api/instance';
+import getAccessToken from '@/service/api/reservation-list/getAccessToken';
+import {ServerError} from '@/types/server-error.types';
 
 const postReservation = async ({pageID, body}: {pageID: string; body: ReservationPost}) => {
-  const res = await INSTANCE_URL.post(`/activities/${pageID}/reservations`, body);
-
-  return res.data;
+  try {
+    const res = await INSTANCE_URL.post(`/activities/${pageID}/reservations`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `Bearer ${getAccessToken()}`,
+      },
+    });
+    return res.data;
+  } catch (e: unknown) {
+    const serverError = e as ServerError;
+    const serverMessage = serverError.response?.data?.message || '알 수 없는 오류가 발생했어요.';
+    throw new Error(serverMessage);
+  }
 };
 
 export default postReservation;

--- a/types/activities-info.ts
+++ b/types/activities-info.ts
@@ -69,3 +69,11 @@ export interface ReservationPost {
   scheduleId: number;
   headCount: number;
 }
+
+export interface ReservationInfoType {
+  person: number;
+  scheduleModal: boolean;
+  personModal: boolean;
+  schedule: SchedulesDateType;
+  daySchedule: SchedulesType;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

ex) #61 #113 

## 📝작업 내용
- 페이지 첫랜딩시 오늘 날짜로 스케쥴 조회
- 월 변경시 현재일 기준으로 월만 바꿔 스케쥴 조회
- 상태 관리 변경( state -> useReducer)
각 컴포넌트에서 state로 관리하였으나 부모 컴포넌트로 값을 전달 후 리랜더링시 데이터 날아가는 이슈가 있어 변경
- 디바이스별 예약 모달 디자인 수정
- 모바일 예약 인원 모달 추가
- 체험 생성 유저에게만 수정 및 삭제 기능 오픈 (myPage 병렬 라우팅 작업 완료시 수정/삭제 링크 이동으로 수정 필요)
## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)

