### PR TITLE
로그인페이지 간편로그인 로그인, 회원가입 분리

### DIFF
--- a/app/oauth/kakao/page.tsx
+++ b/app/oauth/kakao/page.tsx
@@ -5,7 +5,6 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
 import { postOAuth } from '@/service/api/oauth/postOAuth.api';
 import { postOAuthSignin } from '@/service/api/oauth/postOAuthSignin.api';
-import { postOAuthSignup } from '@/service/api/oauth/postOAuthSignup.api';
 import { useAuthStore } from '@/service/store/authStore';
 import { AxiosError } from 'axios';
 
@@ -44,27 +43,9 @@ export default function Page() {
 
           router.push('/');
         } catch (error: unknown) {
-          if (error instanceof AxiosError && error.response?.status === 404) {
-            try {
-              const signupResponse = await postOAuthSignup({
-                nickname: '기본 닉네임',
-                redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI || '',
-                token: token,
-              });
-
-              console.log('회원가입 성공:', signupResponse);
-              const { setLogin } = useAuthStore.getState();
-              setLogin(
-                signupResponse.accessToken,
-                signupResponse.refreshToken,
-                signupResponse.user
-              );
-
-              router.push('/');
-            } catch (signupError) {
-              console.error('회원가입 실패:', signupError);
-              router.push('/signin');
-            }
+          if (error instanceof AxiosError && (error.response?.status === 403 || error.response?.status === 404)) {
+            console.log('회원가입이 필요합니다. /signup 페이지로 이동합니다.');
+            router.push(`/signup?code=${token}`);
           } else {
             console.error('로그인 에러:', error);
             router.push('/signin');

--- a/app/oauth/kakao/signup/page.tsx
+++ b/app/oauth/kakao/signup/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { postOAuthSignup } from '@/service/api/oauth/postOAuthSignup.api';
+import { useAuthStore } from '@/service/store/authStore';
+import { AxiosError } from 'axios';
+
+export default function SignUpPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = searchParams.get('code');
+    if (!token) {
+      setError('잘못된 접근입니다.');
+      router.push('/signin');
+      return;
+    }
+
+    handleSignup(token);
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, [searchParams]);
+
+  const handleSignup = async (token: string) => {
+    const redirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI2 || '';
+
+    try {
+      setIsLoading(true);
+
+      const signupResponse = await postOAuthSignup({
+        nickname: `User`,
+        redirectUri,
+        token,
+      });
+
+      console.log('회원가입 성공:', signupResponse);
+      saveSession(signupResponse.accessToken, signupResponse.refreshToken, signupResponse.user);
+
+      router.push('/signin');
+    } catch (error) {
+      const axiosError = error as AxiosError; 
+      console.log('회원가입 실패:', axiosError?.response?.data);
+      alert('이미 가입된 사용자입니다.')
+      setError('이미 가입된 사용자입니다.');
+      router.push('/signin');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const saveSession = (accessToken: string, refreshToken: string, user: { id: number; email: string; nickname: string; profileImageUrl: string | null; createdAt: string; updatedAt: string; }) => {
+    const { setLogin } = useAuthStore.getState();
+    setLogin(accessToken, refreshToken, user);
+
+    localStorage.setItem('accessToken', accessToken);
+    localStorage.setItem('refreshToken', refreshToken);
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-100">
+      {isLoading ? (
+        <p className="text-gray-700 text-lg">회원가입 중...</p>
+      ) : error ? (
+        <div className="text-red-500 text-lg text-center">
+          <p>{error}</p>
+          <button onClick={() => router.push('/signin')} className="mt-4 px-4 py-2 bg-blue-500 text-white rounded">
+            다시 로그인하기
+          </button>
+        </div>
+      ) : (
+        <p className="text-gray-700 text-lg">회원가입 준비 완료</p>
+      )}
+    </div>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -64,7 +64,7 @@ export default function Page() {
   const passwordValue = watch('password');
 
   const handleKakaoLogin = () => {
-    const kakaoAuthURL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI}&response_type=code`;
+    const kakaoAuthURL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI2}&response_type=code`;
     window.location.href = kakaoAuthURL;
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #96 

## 📝작업 내용

- 로그인과 회원가입 분리했습니다.

## 📷스크린샷 (선택)
- console
<img width="430" alt="스크린샷 2025-02-11 오후 4 32 34" src="https://github.com/user-attachments/assets/286ceee9-2c82-4172-bcff-8ac71661d9f9" />

- 사용자 화면
<img width="1421" alt="스크린샷 2025-02-11 오후 4 32 38" src="https://github.com/user-attachments/assets/d4488260-7cd3-4874-93ee-8ff665cbdc39" />

## 💬리뷰 요구사항(선택)
간편로그인 관련으로 계속 뜯어보니까 오류가 생기는 이유가 인가 토큰 유효성에 대한 문제인것 같아요.
인가 토큰이 알아보니 한번 사용후 만료가 된다고 나와있더라고요.

문서에 보면,
'로그인 응답으로 404 Error 일 경우 회원가입을 진행해주세요.'
이라는 문구가 있어서 로그인할때 발급받은 토큰을 이어서 회원가입을 한번에 진행하면 될것 같아서 한번에 코드를 짯는데, 이걸 백엔드에서 지원을 안하는 것 같아요.

그러고 추가로 403 Error도 있어서 추가하겠습니다.

그래서 개선사항으로,
로그인 페이지에서 간편로그인 진행 -> 403, 404 오류 생성 -> 회원가입페이지 이동 -> 회원가입 진행 -> 로그인페이지로 이동
로그인페이지에서 간편로그인 진행 -> 성공 -> 메인페이지 이동

이렇게 하는게 오류도 없고 진행이 원할하게 진행되네요.
처음에 로직 짠거는 계속 뜯어보니 백엔드에서 로직을 만들어주면 가능할 것 같지만, 지금 저희 상황으론 불가능한거 같습니다.
그래서 .env에 다음 항목 추가해야되고,
NEXT_PUBLIC_KAKAO_REST_API_KEY=
NEXT_PUBLIC_KAKAO_REDIRECT_URI=http://localhost:3000/oauth/kakao
NEXT_PUBLIC_KAKAO_REDIRECT_URI2=http://localhost:3000/oauth/kakao/signup

kakao develop에서 Redirect URI에
http://localhost:3000/
http://localhost:3000/oauth/kakao
http://localhost:3000/oauth/kakao/signup
이렇게 등록해주시면 테스트 가능합니다.