### PR TITLE
1차 QA 반영

### DIFF
--- a/app/ClientSideLayout.tsx
+++ b/app/ClientSideLayout.tsx
@@ -13,7 +13,7 @@ export default function ClientSideLayout({children}: Readonly<{children: React.R
 
   const hideFooter = pathname === '/mypage' || pathname === '/signin' || pathname === '/signup';
 
-  const hideNavbar = pathname === '/login' || pathname === '/signin';
+  const hideNavbar = pathname === '/login' || pathname === '/signin' || pathname === '/signup';
 
   useEffect(() => {
     setQueryClient(new QueryClient());

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -85,7 +85,7 @@ export default function Page() {
 
   return (
     <>
-      <div className="desktop:pt-[7.375rem] desktop:gap-[3.5rem] m-auto flex max-w-[40rem] flex-col items-center gap-[1.5rem] pt-[6.875rem] tablet:gap-[2.5rem] tablet:pt-[7.875rem]">
+      <div className="pt-[6.875rem] gap-[1.5rem] m-auto flex max-w-[40rem] flex-col items-center desktop:pt-[7.375rem] desktop:gap-[3.5rem] desktop:w-[640px] desktop:h-[779px] desktop:top-[118px] desktop:left-[640px] tablet:gap-[2.5rem] tablet:pt-[7.875rem] tablet:w-[640px] tablet:h-[779px] tablet:top-[118px] tablet:left-[52px]">
         <Link href="/">
           <Image src={signLogo} alt="로고" />
         </Link>
@@ -158,9 +158,11 @@ export default function Page() {
             </span>
             <div className="flex flex-col gap-[1.5rem] tablet:gap-[2.5rem]">
               <div className="flex items-center justify-center">
-                <hr className="w-[5rem] border border-gray-300" />
-                <span className="text-center text-[0.875rem] font-regular leading-[1.5rem] text-gray-700">SNS 계정으로 로그인하기</span>
-                <hr className="w-[5rem] border border-gray-300" />
+                <hr className="w-[180px] border border-gray-300" />
+                <span className="text-center text-[0.875rem] font-regular leading-[1.5rem] text-gray-700 w-[205px] h-[32px]">
+                  SNS 계정으로 로그인하기
+                </span>
+                <hr className="w-[180px] border border-gray-300" />
               </div>
               <div className="flex justify-center gap-[1rem]">
                 <button type="button" onClick={() => alert('Google 로그인 기능이 일시적으로 제한되어 있습니다')}>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -56,7 +56,7 @@ export default function Page() {
       onSuccess: () => {
         setModalMessage('가입이 완료되었습니다!');
         setIsModalOpen(true);
-        router.push('/');
+        router.push('/signin');
       },
     });
   };

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -70,7 +70,7 @@ export default function Page() {
 
   return (
     <>
-      <div className="desktop:pt-[7.375rem] desktop:gap-[3.5rem] m-auto flex max-w-[40rem] flex-col items-center gap-[1.5rem] pt-[6.875rem] tablet:gap-[2.5rem] tablet:pt-[7.875rem]">
+      <div className="pt-[6.875rem] gap-[1.5rem] m-auto flex max-w-[40rem] flex-col items-center desktop:pt-[7.375rem] desktop:gap-[3.5rem] desktop:w-[640px] desktop:h-[1019px] desktop:top-[118px] desktop:left-[640px] tablet:gap-[2.5rem] tablet:pt-[7.875rem] tablet:w-[640px] tablet:h-[1003px] tablet:top-[118px] tablet:left-[52px]">
         <Link href="/">
           <Image src={signLogo} alt="로고" />
         </Link>
@@ -194,12 +194,12 @@ export default function Page() {
               </Link>
             </span>
             <div className="flex flex-col gap-[1.5rem] tablet:gap-[2.5rem]">
-              <div className="flex justify-center items-center">
-                <hr className="w-[5rem] border border-gray-300" />
-                <span className="text-center text-[0.875rem] font-regular leading-[1.5rem] text-gray-700">
+              <div className="flex items-center justify-center">
+                <hr className="w-[180px] border border-gray-300" />
+                <span className="text-center text-[0.875rem] font-regular leading-[1.5rem] text-gray-700 w-[222px] h-[32px]">
                   SNS 계정으로 회원가입하기
                 </span>
-                <hr className="w-[5rem] border border-gray-300" />
+                <hr className="w-[180px] border border-gray-300" />
               </div>
               <div className="flex justify-center gap-[1rem]">
                 <button type="button" onClick={() => alert("Google 로그인 기능이 일시적으로 제한되어 있습니다")}>

--- a/components/common/navbar.tsx
+++ b/components/common/navbar.tsx
@@ -28,7 +28,7 @@ export default function Navbar() {
 
   const handleDropdownItemClick = (type: string) => {
     if (type === 'mypage') {
-      router.push('/mypage');
+      router.push('/mypage/myinfo');
     } else if (type === 'logout') {
       handleLogout();
     }

--- a/components/common/navbar.tsx
+++ b/components/common/navbar.tsx
@@ -28,7 +28,7 @@ export default function Navbar() {
 
   const handleDropdownItemClick = (type: string) => {
     if (type === 'mypage') {
-      router.push('/mypage/myinfo');
+      router.push('/mypage');
     } else if (type === 'logout') {
       handleLogout();
     }

--- a/components/side-navigation/mypage.tsx
+++ b/components/side-navigation/mypage.tsx
@@ -8,7 +8,7 @@ import {EditMypageBody} from '@/types/patchMypage.types';
 import Input from '@/components/common/Input';
 import Button from '@/components/common/button';
 import Modal from '@/components/common/modal/modal';
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import closeButton from '@/public/icon/ic_close_button.svg';
 import {useRouter} from 'next/navigation';
 import Image from 'next/image';
@@ -39,6 +39,14 @@ export default function MyPage() {
     },
   });
   const router = useRouter();
+
+  useEffect(() => {
+    if (!user) {
+      router.push('/signin');
+    } else {
+      router.push('/mypage/myinfo');
+    }
+  }, [user, router]);
 
   const mypageMutation = useMutation({
     mutationFn: (mypageData: EditMypageBody) => patchMypage(mypageData),

--- a/components/side-navigation/mypage.tsx
+++ b/components/side-navigation/mypage.tsx
@@ -43,9 +43,7 @@ export default function MyPage() {
   useEffect(() => {
     if (!user) {
       router.push('/signin');
-    } else {
-      router.push('/mypage/myinfo');
-    }
+    } 
   }, [user, router]);
 
   const mypageMutation = useMutation({


### PR DESCRIPTION
## #️⃣연관된 이슈

#136 

## 📝작업 내용

- 로그인, 회원가입
1. 공통) 하단 여백 필요 -> 따로 하단 여백이 있는게 아니라 전체 높이가 설정되어있어 디바이스마다 다른것 같아요
2. 공통 ) sns 계정으로 문구 사이 —— 여백필요
3. 회원가입 ) 가입 후 로그인 페이지로 이동 필요
4. 회원가입) nav 바 없애기

- 네비바
1. 마이페이지 클릭시 myinfo로 이동

- 내정보
1. 로그인 안되면 signin 페이지로 이동

## 📷스크린샷 (선택)

- 로그인
<img width="895" alt="스크린샷 2025-02-11 오후 6 51 56" src="https://github.com/user-attachments/assets/799b29d7-ff64-4f5a-84ea-d1cc6cd7b9b3" />

- 회원가입
<img width="598" alt="스크린샷 2025-02-11 오후 6 52 36" src="https://github.com/user-attachments/assets/9cda1543-df10-4a3a-9abc-4dc8eceb7634" />

- 내정보
<img width="1916" alt="스크린샷 2025-02-11 오후 6 55 49" src="https://github.com/user-attachments/assets/b966f46f-602c-497e-975d-bffb383701c0" />


## 💬리뷰 요구사항(선택)
- input에서 가리기 기능 위치가 고정되어있는것 같아요. 실제로 컴포넌트로 가져다 쓰기만해서 제 오류인지 컴포넌트 오류인지 잘 모르겠습니다!
<img width="486" alt="스크린샷 2025-02-11 오후 6 54 06" src="https://github.com/user-attachments/assets/7f8b8ab8-bca1-49f2-9459-e86e936e3deb" />

- 태완님이 적어주신건데, 마이페이지에서도 비율을 100%이하로하면, footer가 아래 공백이 생깁니다! 해결해야될것 같아요
<img width="962" alt="스크린샷 2025-02-11 오후 6 56 41" src="https://github.com/user-attachments/assets/cf476b36-e217-4745-ae31-e0558c30ade6" />