### PR TITLE
[fix] 체험 상세 삭제시 리랜더링 버그 수정

### DIFF
--- a/components/activities/reviews.tsx
+++ b/components/activities/reviews.tsx
@@ -1,22 +1,24 @@
 'use client';
 import React, {useState} from 'react';
 import {useQuery} from 'react-query';
-import {getActivitiesReviews} from '@/service/api/activities/getActivitiesInfo';
+import {useParams} from 'next/navigation';
 import {ActivitiesReviewsType} from '@/types/activities-info';
 import Image from 'next/image';
-import FormatDate from '@/utils/format-date';
+import {getActivitiesReviews} from '@/service/api/activities/getActivitiesInfo';
 import Pagenation from '@/components/common/pagenation';
+import FormatDate from '@/utils/format-date';
 import Star from '@/public/icon/ic_star.svg';
 import DefaultProfile from '@/public/img/img_default_profile.svg';
 
-const Reviews = ({pageID}: {pageID: string}) => {
+const Reviews = () => {
+  const params = useParams();
   const [page, setPage] = useState<number>(1);
+  const pageID = params?.id?.toString() || '';
 
   const {data, isSuccess} = useQuery<ActivitiesReviewsType>({
     queryKey: ['activitiesReviews', page],
     queryFn: () => getActivitiesReviews(pageID, 1, 3),
     enabled: !!page,
-    notifyOnChangeProps: ['data'],
   });
 
   const handlePageChange = (page: number) => {

--- a/components/activities/side-reservation.tsx
+++ b/components/activities/side-reservation.tsx
@@ -1,89 +1,70 @@
 'use client';
-import React, {useReducer} from 'react';
+import React, {useState} from 'react';
 import {useMutation} from 'react-query';
-import {ReservationInfoType, SchedulesDateType, SchedulesType} from '@/types/activities-info';
-import dayjs from 'dayjs';
+import {useParams, useRouter} from 'next/navigation';
+import {ResultModalType} from '@/types/common/alert-modal.types';
 import Image from 'next/image';
 import SmCalendar from '@/components/activities/sm-calendar';
+import activitiesStore from '@/service/store/activitiesstore';
 import Button from '@/components/common/button';
 import OverlayContainer from '@/components/common/modal/overlay-container';
+import AlertModal from '@/components/common/modal/alert-modal';
 import FormatNumberWithCommas from '@/utils/format-number';
 import postReservation from '@/service/api/activities/postActivities';
 import Plus from '@/public/icon/icon_plus.png';
 import Minus from '@/public/icon/icon_minus.png';
 import Cancle from '@/public/icon/icon_cancle.png';
 
-const initialState: ReservationInfoType = {
-  person: 1,
-  scheduleModal: false,
-  personModal: false,
-  schedule: {date: '', startTime: '', endTime: '', id: 0},
-  daySchedule: {date: dayjs().format('YYYY-MM-DD'), times: []},
-};
-
-type Action =
-  | {type: 'SET_PERSON'; payload: number}
-  | {type: 'SET_SCHEDULE_MODAL'; payload: boolean}
-  | {type: 'SET_PERSON_MODAL'; payload: boolean}
-  | {type: 'SET_SCHEDULE'; payload: SchedulesDateType}
-  | {type: 'SET_DAY_SCHEDULE'; payload: SchedulesType};
-
 interface ReservationProps {
   pageID: string;
   price: number;
-  state: ReservationInfoType;
-  dispatch: React.Dispatch<Action>;
+  person: number;
+  selectedSchedule: {date: string; startTime: string; endTime: string; id: number};
+  scheduleModal?: boolean;
+  personModal?: boolean;
   updatePerson: (count: number) => void;
-  updateSchedule: (schedule: SchedulesDateType) => void;
   saveReservation: () => void;
 }
 
-const reservationReducer: (state: ReservationInfoType, action: Action) => ReservationInfoType = (state, action) => {
-  switch (action.type) {
-    case 'SET_PERSON':
-      return {...state, person: action.payload};
-    case 'SET_SCHEDULE_MODAL':
-      return {...state, scheduleModal: action.payload};
-    case 'SET_PERSON_MODAL':
-      return {...state, personModal: action.payload};
-    case 'SET_SCHEDULE':
-      return {...state, schedule: action.payload};
-    case 'SET_DAY_SCHEDULE':
-      return {...state, daySchedule: action.payload};
-    default:
-      return state;
-  }
-};
-
-const Reservation = ({device, pageID, price}: {device: string; pageID: string; price: number}) => {
-  const [state, dispatch] = useReducer(reservationReducer, initialState);
+const Reservation = ({device, price}: {device: string; price: number}) => {
+  const params = useParams();
+  const {person, selectedSchedule, scheduleModal, personModal, updatePerson} = activitiesStore();
+  const [isPostResultModalOpen, setIsPostResultModalOpen] = useState<ResultModalType>({comment: '', isOpen: false});
+  const [isNotiModalOpen, setIsNotiModalOpen] = useState<ResultModalType>({comment: '', isOpen: false});
+  const router = useRouter();
+  const pageID = params?.id?.toString() || '';
 
   const mutation = useMutation(postReservation, {
     onSuccess: () => {
-      alert('체험 예약을 완료했습니다.');
+      setIsPostResultModalOpen({comment: '체험 예약을 완료했습니다.', isOpen: true});
     },
-    onError: (error: unknown) => {
+    onError: error => {
       if (error instanceof Error) {
-        alert(error.message);
+        setIsPostResultModalOpen({comment: error.message, isOpen: true});
       } else {
-        alert('알 수 없는 오류가 발생했습니다.');
+        setIsPostResultModalOpen({comment: '알 수 없는 오류가 발생했습니다.', isOpen: true});
       }
     },
   });
 
-  const handleSelectSchedule = (schedule: SchedulesDateType) => {
-    dispatch({type: 'SET_SCHEDULE', payload: schedule});
+  const handleClosePostResultModal = () => {
+    setIsPostResultModalOpen({comment: '', isOpen: false});
+    router.push('/');
+  };
+
+  const handleCloseNotiModal = () => {
+    setIsNotiModalOpen({comment: '', isOpen: false});
   };
 
   const handleUpdatePerson = (count: number) => {
-    const person = state.person + count;
-    if (person < 1) return alert('최소 예약 인원은 1명입니다.');
-    dispatch({type: 'SET_PERSON', payload: person});
+    const total = person + count;
+    if (total < 1) return setIsNotiModalOpen({comment: '최소 예약 인원은 1명입니다.', isOpen: true});
+    updatePerson(count);
   };
 
   const handleSaveReservation = () => {
-    if (!state.schedule) return alert('예약 정보가 없습니다.');
-    mutation.mutate({pageID: pageID, body: {scheduleId: state.schedule.id, headCount: state.person}});
+    if (!selectedSchedule) return setIsNotiModalOpen({comment: '예약 정보가 없습니다.', isOpen: true});
+    mutation.mutate({pageID: pageID, body: {scheduleId: selectedSchedule.id, headCount: person}});
   };
 
   const ReservationDeviceType = ({device}: {device: string}) => {
@@ -93,9 +74,8 @@ const Reservation = ({device, pageID, price}: {device: string; pageID: string; p
           <ReservationWindowsType
             pageID={pageID}
             price={price}
-            state={state}
-            dispatch={dispatch}
-            updateSchedule={handleSelectSchedule}
+            person={person}
+            selectedSchedule={selectedSchedule}
             updatePerson={handleUpdatePerson}
             saveReservation={handleSaveReservation}
           />
@@ -105,9 +85,9 @@ const Reservation = ({device, pageID, price}: {device: string; pageID: string; p
           <ReservationTabletType
             pageID={pageID}
             price={price}
-            state={state}
-            dispatch={dispatch}
-            updateSchedule={handleSelectSchedule}
+            person={person}
+            selectedSchedule={selectedSchedule}
+            scheduleModal={scheduleModal}
             updatePerson={handleUpdatePerson}
             saveReservation={handleSaveReservation}
           />
@@ -117,9 +97,10 @@ const Reservation = ({device, pageID, price}: {device: string; pageID: string; p
           <ReservationMobileType
             pageID={pageID}
             price={price}
-            state={state}
-            dispatch={dispatch}
-            updateSchedule={handleSelectSchedule}
+            person={person}
+            selectedSchedule={selectedSchedule}
+            scheduleModal={scheduleModal}
+            personModal={personModal}
             updatePerson={handleUpdatePerson}
             saveReservation={handleSaveReservation}
           />
@@ -127,16 +108,22 @@ const Reservation = ({device, pageID, price}: {device: string; pageID: string; p
     }
   };
 
-  return <ReservationDeviceType device={device} />;
+  return (
+    <>
+      <ReservationDeviceType device={device} />
+      {isPostResultModalOpen.isOpen && <AlertModal comment={isPostResultModalOpen.comment} isOpen={handleClosePostResultModal} />}
+      {isNotiModalOpen.isOpen && <AlertModal comment={isNotiModalOpen.comment} isOpen={handleCloseNotiModal} />}
+    </>
+  );
 };
 
-const ReservationWindowsType = ({pageID, price, state, dispatch, updateSchedule, updatePerson, saveReservation}: ReservationProps) => {
+const ReservationWindowsType = ({pageID, price, person, selectedSchedule, updatePerson, saveReservation}: ReservationProps) => {
   return (
     <div className="rounded-xl border border-solid border-gray-200 bg-white px-24pxr pb-18pxr pt-24pxr shadow-sidenavi-box tablet:h-full pc:min-h-748pxr pc:min-w-384pxr">
       <div className="mb-16pxr">
         <div className="flex w-auto flex-row gap-3">
           <p className="mb-16pxr text-3xl font-bold text-black-100">{`₩ ${FormatNumberWithCommas(price)}`}</p>
-          <p className="mb-16pxr text-2xl font-normal leading-10 text-gray-800">{`/ ${state.person}인`}</p>
+          <p className="mb-16pxr text-2xl font-normal leading-10 text-gray-800">{`/ ${person}인`}</p>
         </div>
         <hr />
       </div>
@@ -144,7 +131,7 @@ const ReservationWindowsType = ({pageID, price, state, dispatch, updateSchedule,
         <div className="flex w-auto flex-row gap-3">
           <p className="mb-16pxr text-xl font-bold text-nomad-black">날짜</p>
         </div>
-        <SmCalendar pageID={pageID} state={state} dispatch={dispatch} onSelect={updateSchedule} />
+        <SmCalendar pageID={pageID} />
       </div>
       <hr />
       <div className="mb-24pxr mt-12pxr">
@@ -156,7 +143,7 @@ const ReservationWindowsType = ({pageID, price, state, dispatch, updateSchedule,
           >
             <Image src={Minus} width={20} height={20} alt="minus" />
           </Button>
-          <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{state.person}</p>
+          <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{person}</p>
           <Button
             className="relative h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr"
             onClick={() => updatePerson(1)}
@@ -165,8 +152,8 @@ const ReservationWindowsType = ({pageID, price, state, dispatch, updateSchedule,
           </Button>
         </div>
         <Button
-          className={`my-24pxr flex h-56pxr w-full flex-row items-center justify-center gap-4pxr rounded-s px-8pxr py-40pxr ${!state.schedule?.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
-          disabled={!state.schedule?.id}
+          className={`my-24pxr flex h-56pxr w-full flex-row items-center justify-center gap-4pxr rounded-s px-8pxr py-40pxr ${!selectedSchedule?.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
+          disabled={!selectedSchedule?.id}
           onClick={saveReservation}
         >
           <p className="text-lg font-bold text-white">예약하기</p>
@@ -175,15 +162,17 @@ const ReservationWindowsType = ({pageID, price, state, dispatch, updateSchedule,
       <hr />
       <div className="mt-16pxr flex flex-row items-center justify-between">
         <p className="text-xl font-bold text-nomad-black">총 합계</p>
-        <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * state.person)}`}</p>
+        <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * person)}`}</p>
       </div>
     </div>
   );
 };
 
-const ReservationTabletType = ({pageID, price, state, dispatch, updateSchedule, updatePerson, saveReservation}: ReservationProps) => {
+const ReservationTabletType = ({pageID, price, person, selectedSchedule, scheduleModal, updatePerson, saveReservation}: ReservationProps) => {
+  const {updateScheduleModal} = activitiesStore();
+
   const handleOpenModal = (status: boolean) => {
-    dispatch({type: 'SET_SCHEDULE_MODAL', payload: status});
+    updateScheduleModal(status);
   };
 
   return (
@@ -191,7 +180,7 @@ const ReservationTabletType = ({pageID, price, state, dispatch, updateSchedule, 
       <div className="mb-16pxr">
         <div className="flex w-auto flex-row gap-3">
           <p className="mb-16pxr text-2xl font-bold text-black-100">{`₩ ${FormatNumberWithCommas(price)}`}</p>
-          <p className="mb-16pxr text-2xl font-normal leading-8 text-gray-800">{`/ ${state.person}인`}</p>
+          <p className="mb-16pxr text-2xl font-normal leading-8 text-gray-800">{`/ ${person}인`}</p>
         </div>
         <hr />
       </div>
@@ -205,8 +194,8 @@ const ReservationTabletType = ({pageID, price, state, dispatch, updateSchedule, 
         >
           날짜 선택하기
         </Button>
-        {state.schedule.date.length > 0 && (
-          <p className="text-lg font-semibold text-nomad-black">{`${state.schedule.date} ${state.schedule.startTime} ~ ${state.schedule.endTime}`}</p>
+        {selectedSchedule.date.length > 0 && (
+          <p className="text-lg font-semibold text-nomad-black">{`${selectedSchedule.date} ${selectedSchedule.startTime} ~ ${selectedSchedule.endTime}`}</p>
         )}
       </div>
       <hr />
@@ -219,7 +208,7 @@ const ReservationTabletType = ({pageID, price, state, dispatch, updateSchedule, 
           >
             <Image src={Minus} width={20} height={20} alt="minus" />
           </Button>
-          <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{state.person}</p>
+          <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{person}</p>
           <Button
             className="relative h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr"
             onClick={() => updatePerson(1)}
@@ -228,8 +217,8 @@ const ReservationTabletType = ({pageID, price, state, dispatch, updateSchedule, 
           </Button>
         </div>
         <Button
-          className={`my-24pxr flex h-56pxr w-full flex-row items-center justify-center gap-4pxr rounded-md px-8pxr py-40pxr ${!state.schedule.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
-          disabled={state.schedule.id === 0}
+          className={`my-24pxr flex h-56pxr w-full flex-row items-center justify-center gap-4pxr rounded-md px-8pxr py-40pxr ${!selectedSchedule.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
+          disabled={selectedSchedule.id === 0}
           onClick={saveReservation}
         >
           <p className="text-lg font-bold text-white">예약하기</p>
@@ -238,9 +227,9 @@ const ReservationTabletType = ({pageID, price, state, dispatch, updateSchedule, 
       <hr />
       <div className="mt-16pxr flex flex-row items-center justify-between">
         <p className="text-xl font-bold text-nomad-black">총 합계</p>
-        <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * state.person)}`}</p>
+        <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * person)}`}</p>
       </div>
-      {state.scheduleModal && (
+      {scheduleModal && (
         <OverlayContainer onClose={() => handleOpenModal(false)}>
           <div className="relative max-h-700pxr w-480pxr rounded-3xl bg-white px-24pxr pb-32pxr pt-28pxr" onClick={e => e.stopPropagation()}>
             <div className="mb-30pxr flex flex-row justify-between">
@@ -250,11 +239,11 @@ const ReservationTabletType = ({pageID, price, state, dispatch, updateSchedule, 
               </Button>
             </div>
             <div className="mb-100pxr">
-              <SmCalendar pageID={pageID} state={state} dispatch={dispatch} onSelect={updateSchedule} />
+              <SmCalendar pageID={pageID} />
             </div>
             <Button
-              className={`absolute bottom-32pxr left-24pxr flex h-56pxr min-w-432pxr items-center justify-center rounded-md ${!state.schedule.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
-              disabled={!state.schedule.id}
+              className={`absolute bottom-32pxr left-24pxr flex h-56pxr min-w-432pxr items-center justify-center rounded-md ${!selectedSchedule.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
+              disabled={!selectedSchedule.id}
               onClick={() => handleOpenModal(false)}
             >
               <p className="text-lg font-bold text-white">확인</p>
@@ -266,17 +255,29 @@ const ReservationTabletType = ({pageID, price, state, dispatch, updateSchedule, 
   );
 };
 
-const ReservationMobileType = ({pageID, price, state, dispatch, updateSchedule, updatePerson, saveReservation}: ReservationProps) => {
+const ReservationMobileType = ({
+  pageID,
+  price,
+  person,
+  selectedSchedule,
+  scheduleModal,
+  personModal,
+  updatePerson,
+  saveReservation,
+}: ReservationProps) => {
+  const {updateScheduleModal, updatePersonModal} = activitiesStore();
+
   const handleOpenScheduleModal = (status: boolean) => {
-    dispatch({type: 'SET_SCHEDULE_MODAL', payload: status});
+    updateScheduleModal(status);
   };
+
   const handleOpenPersonModal = () => {
-    dispatch({type: 'SET_SCHEDULE_MODAL', payload: false});
-    dispatch({type: 'SET_PERSON_MODAL', payload: true});
+    updateScheduleModal(false);
+    handleClosePersonModal(true);
   };
 
   const handleClosePersonModal = (status: boolean) => {
-    dispatch({type: 'SET_PERSON_MODAL', payload: status});
+    updatePersonModal(status);
   };
 
   return (
@@ -285,23 +286,23 @@ const ReservationMobileType = ({pageID, price, state, dispatch, updateSchedule, 
         <div className="flex flex-row flex-wrap justify-between px-18pxr py-18pxr">
           <div className="flex flex-col items-start">
             <div className="flex h-35pxr w-auto flex-row gap-3">
-              <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * state.person)}`}</p>
-              <p className="mb-16pxr text-xl font-normal leading-8 text-gray-800">{`/ ${state.person}인`}</p>
+              <p className="text-xl font-bold text-nomad-black">{`₩ ${FormatNumberWithCommas(price * person)}`}</p>
+              <p className="mb-16pxr text-xl font-normal leading-8 text-gray-800">{`/ ${person}인`}</p>
             </div>
             <Button className="border-0 bg-white text-lg font-semibold text-primary" onClick={() => handleOpenScheduleModal(true)}>
               <ins>날짜 선택하기</ins>
             </Button>
           </div>
           <Button
-            className={`h-48pxr min-w-106pxr items-center justify-center rounded-md text-lg font-bold text-white ${!state.schedule.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
-            disabled={state.schedule.id === 0}
+            className={`h-48pxr min-w-106pxr items-center justify-center rounded-md text-lg font-bold text-white ${!selectedSchedule.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
+            disabled={selectedSchedule.id === 0}
             onClick={saveReservation}
           >
             예약하기
           </Button>
         </div>
       </div>
-      {state.scheduleModal && (
+      {scheduleModal && (
         <OverlayContainer onClose={() => handleOpenScheduleModal(false)}>
           <div className="relative h-full w-373pxr bg-white px-24pxr pb-40pxr pt-24pxr" onClick={e => e.stopPropagation()}>
             <div className="mb-30pxr flex flex-row justify-between">
@@ -312,10 +313,10 @@ const ReservationMobileType = ({pageID, price, state, dispatch, updateSchedule, 
                 <Image src={Cancle} width={40} height={40} alt="cancle" />
               </Button>
             </div>
-            <SmCalendar pageID={pageID} device={'mobile'} state={state} dispatch={dispatch} onSelect={updateSchedule} />
+            <SmCalendar pageID={pageID} device={'mobile'} />
             <Button
-              className={`absolute bottom-40pxr left-24pxr flex h-56pxr min-w-327pxr flex-row items-center justify-center rounded-md ${!state.schedule?.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
-              disabled={!state.schedule.id}
+              className={`absolute bottom-40pxr left-24pxr flex h-56pxr min-w-327pxr flex-row items-center justify-center rounded-md ${!selectedSchedule?.id ? 'bg-gray-400' : 'bg-nomad-black'}`}
+              disabled={!selectedSchedule.id}
               onClick={handleOpenPersonModal}
             >
               <p className="text-lg font-bold text-white">다음</p>
@@ -323,7 +324,7 @@ const ReservationMobileType = ({pageID, price, state, dispatch, updateSchedule, 
           </div>
         </OverlayContainer>
       )}
-      {state.personModal && (
+      {personModal && (
         <OverlayContainer onClose={() => handleClosePersonModal(false)}>
           <div className="relative h-full min-w-373pxr bg-white px-24pxr pb-40pxr pt-24pxr" onClick={e => e.stopPropagation()}>
             <div className="mb-30pxr flex flex-row justify-between">
@@ -343,7 +344,7 @@ const ReservationMobileType = ({pageID, price, state, dispatch, updateSchedule, 
                 >
                   <Image src={Minus} width={20} height={20} alt="minus" />
                 </Button>
-                <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{state.person}</p>
+                <p className="h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr">{person}</p>
                 <Button
                   className="relative h-40pxr w-40pxr flex-row items-start justify-center rounded-s-md bg-white p-10pxr"
                   onClick={() => updatePerson(1)}
@@ -354,7 +355,7 @@ const ReservationMobileType = ({pageID, price, state, dispatch, updateSchedule, 
             </div>
             <Button
               className="absolute bottom-40pxr left-24pxr flex h-56pxr min-w-327pxr flex-row items-center justify-center rounded-md bg-nomad-black"
-              disabled={!state.schedule.id}
+              disabled={!selectedSchedule.id}
               onClick={() => handleClosePersonModal(false)}
             >
               <p className="text-lg font-bold text-white">확인</p>

--- a/components/common/modal/alert-modal.tsx
+++ b/components/common/modal/alert-modal.tsx
@@ -1,0 +1,32 @@
+'use client';
+import React from 'react';
+import {AlertModalType} from '@/types/common/alert-modal.types';
+import OverlayContainer from '@/components/common/modal/overlay-container';
+import Button from '@/components/common/button';
+import InitialDevice from '@/utils/initial-device';
+
+const AlertModal = ({isOpen, comment}: AlertModalType) => {
+  const getDeviceType = InitialDevice();
+  return (
+    <OverlayContainer onClose={isOpen}>
+      <div className="flex h-220pxr w-327pxr flex-col items-center justify-center rounded-xl bg-white tablet:h-250pxr tablet:w-540pxr pc:h-250pxr pc:w-540pxr">
+        <div className="flex h-172pxr w-full items-center justify-center">
+          <p className="text-center text-2lg font-medium text-[#333236]">{comment}</p>
+        </div>
+        {getDeviceType !== 'mobile' ? (
+          <div className="relative h-48pxr w-full">
+            <Button className="absolute right-28pxr h-48pxr w-120pxr rounded-lg bg-nomad-black" onClick={isOpen}>
+              <p className="text-lg font-medium text-white">확인</p>
+            </Button>
+          </div>
+        ) : (
+          <Button className="mb-24pxr h-48pxr w-120pxr rounded-lg bg-nomad-black" onClick={isOpen}>
+            <p className="text-lg font-medium text-white">확인</p>
+          </Button>
+        )}
+      </div>
+    </OverlayContainer>
+  );
+};
+
+export default AlertModal;

--- a/service/api/activities/deleteActivities.ts
+++ b/service/api/activities/deleteActivities.ts
@@ -4,11 +4,13 @@ import {ServerError} from '@/types/server-error.types';
 
 const deleteReservation = async (pageID: string) => {
   try {
+    const accessToken = await getAccessToken();
+
     const res = await INSTANCE_URL.delete(`/my-activities/${pageID}`, {
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        Authorization: `Bearer ${getAccessToken()}`,
+        Authorization: `Bearer ${accessToken}`,
       },
     });
     return res.data;

--- a/service/api/activities/getActivitiesInfo.ts
+++ b/service/api/activities/getActivitiesInfo.ts
@@ -1,5 +1,5 @@
 import INSTANCE_URL from '@/service/api/instance';
-import {ActivitiesInfoType, ActivitiesReviewsType, SchedulesType} from '@/types/activities-info';
+import {ActivitiesInfoType, ActivitiesReviewsType, SchedulesDateType} from '@/types/activities-info';
 import {ServerError} from '@/types/server-error.types';
 
 export async function getActivitiesInfo(pageID: string): Promise<ActivitiesInfoType> {
@@ -13,7 +13,7 @@ export async function getActivitiesInfo(pageID: string): Promise<ActivitiesInfoT
   }
 }
 
-export async function getActivitiesSchedule(pageID: string, date: string | undefined): Promise<SchedulesType[]> {
+export async function getActivitiesSchedule(pageID: string, date: string | undefined): Promise<SchedulesDateType[]> {
   if (!date) return [];
   const params = new URLSearchParams();
   const splitDate = date.split('-');

--- a/service/store/activitiesstore.tsx
+++ b/service/store/activitiesstore.tsx
@@ -1,0 +1,31 @@
+import dayjs from 'dayjs';
+import {create} from 'zustand';
+import {SchedulesType, SchedulesDateType} from '@/types/activities-info';
+
+interface ActivitiesState {
+  person: number;
+  scheduleModal: boolean;
+  personModal: boolean;
+  selectedSchedule: SchedulesType;
+  dailySchedule: SchedulesDateType;
+  updatePerson: (count: number) => void;
+  updateSelectedSchedule: (data: SchedulesType) => void;
+  updateDailySchedule: (data: SchedulesDateType) => void;
+  updateScheduleModal: (open: boolean) => void;
+  updatePersonModal: (open: boolean) => void;
+}
+
+const activitiesStore = create<ActivitiesState>(set => ({
+  person: 1,
+  scheduleModal: false,
+  personModal: false,
+  selectedSchedule: {date: dayjs().format('YYYY-MM-DD'), startTime: '', endTime: '', id: 0},
+  dailySchedule: {date: dayjs().format('YYYY-MM-DD'), times: []},
+  updatePerson: count => set(state => ({person: state.person + count})),
+  updateSelectedSchedule: data => set(() => ({selectedSchedule: data})),
+  updateDailySchedule: data => set(() => ({dailySchedule: data})),
+  updateScheduleModal: open => set(() => ({scheduleModal: open})),
+  updatePersonModal: open => set(() => ({personModal: open})),
+}));
+
+export default activitiesStore;

--- a/types/activities-info.ts
+++ b/types/activities-info.ts
@@ -33,14 +33,14 @@ export interface SchedulesTimeType {
   id: number;
 }
 
-export interface SchedulesDateType {
+export interface SchedulesType {
   date: string;
   startTime: string;
   endTime: string;
   id: number;
 }
 
-export interface SchedulesType {
+export interface SchedulesDateType {
   date: string;
   times: SchedulesTimeType[];
 }
@@ -68,12 +68,4 @@ export interface ActivitiesReviewsType {
 export interface ReservationPost {
   scheduleId: number;
   headCount: number;
-}
-
-export interface ReservationInfoType {
-  person: number;
-  scheduleModal: boolean;
-  personModal: boolean;
-  schedule: SchedulesDateType;
-  daySchedule: SchedulesType;
 }

--- a/types/common/alert-modal.types.ts
+++ b/types/common/alert-modal.types.ts
@@ -1,0 +1,9 @@
+export interface ResultModalType {
+  comment: string;
+  isOpen: boolean;
+}
+
+export interface AlertModalType {
+  isOpen: () => void;
+  comment: string;
+}

--- a/utils/admin-auth.ts
+++ b/utils/admin-auth.ts
@@ -1,7 +1,16 @@
-const AdminAuth = (userId: number) => {
-  const sessionID = sessionStorage.getItem('userInfo');
-  const updateAuth = sessionID && JSON.parse(sessionID).id === userId;
-  return updateAuth;
+import {ServerError} from '@/types/server-error.types';
+
+const isAdmin = (userId: number) => {
+  try {
+    const sessionID = sessionStorage.getItem('userInfo');
+    if (!sessionID) return false;
+    const updateAuth = JSON.parse(sessionID).id === userId;
+    return updateAuth;
+  } catch (e: unknown) {
+    const serverError = e as ServerError;
+    console.error(serverError.response?.data?.message);
+    return false;
+  }
 };
 
-export default AdminAuth;
+export default isAdmin;


### PR DESCRIPTION
## #️⃣연관된 이슈

ex) #129 

## 📝작업 내용
전역 상태 관리로 변경 ( zustand )
알림 팝업 공통 컴포넌트 추가 및 적용

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)
알림 팝업 사용 예시입니다.

  const [isPostResultModalOpen, setIsPostResultModalOpen] = useState<ResultModalType>({comment: '', isOpen: false});

  const mutation = useMutation({
    mutationFn: async (pageID: string) => {
      await deleteReservation(pageID);
    },
    onSuccess: () => {
      setIsPostResultModalOpen({comment: '등록하신 체험 정보를 삭제했습니다.', isOpen: true});
      queryClient.setQueryData(['activitiesInfo', 'activitiesReviews', 'schedules'], null);
    },
    onError: error => {
      setIsPostResultModalOpen({comment: error.message, isOpen: true});
      router.refresh();
    },
  });
  
    const handleCloseAletModal = () => {
    setIsPostResultModalOpen({comment: '', isOpen: false});
    router.push('/');
  };
  
    return (
    isPostResultModalOpen.isOpen && <AlertModal comment={isPostResultModalOpen.comment} isOpen={handleCloseAletModal} />
  );
