### PR TITLE
[QA 수정] 알림내역 css, 체험수정 일정 scroll 추가

### DIFF
--- a/components/common/lnfiniteScroll.tsx
+++ b/components/common/lnfiniteScroll.tsx
@@ -41,7 +41,7 @@ const InfiniteScroll = <T,>({queryKey, fetchData, render, className}: InfiniteSc
     <>
       <div className={`relative ${className}`}>
         {/* 데이터 영역 */}
-        <div className={`h-full overflow-x-hidden pr-4 ${hasData ? 'custom-scrollbar overflow-y-scroll' : 'overflow-hidden'}`}>
+        <div className={`h-full overflow-x-hidden ${hasData ? 'custom-scrollbar overflow-y-scroll pr-4' : 'overflow-hidden'}`}>
           {data?.pages.map((group, i) => (
             <div key={i} className="relative">
               {render(group)}

--- a/components/common/notification.tsx
+++ b/components/common/notification.tsx
@@ -112,7 +112,7 @@ export default function Notification({className = 'w-auto', onClose}: Notificati
                     const status = getStatus(data.content);
                     return (
                       <Fragment key={data.id}>
-                        <div className="w-full bg-white px-3 py-4 tablet:w-335pxr">
+                        <div className="w-full bg-white px-3 py-4">
                           <div className="flex items-center justify-between">
                             <Image
                               src={status === '승인' ? NotiBlueIcon : NotiRedIcon}

--- a/components/common/notification.tsx
+++ b/components/common/notification.tsx
@@ -1,17 +1,16 @@
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import Image from 'next/image';
+import {QueryFunctionContext, useMutation, useQueryClient} from '@tanstack/react-query';
+import OverlayContainer from '@/components/common/modal/overlay-container';
+import InfiniteScroll from '@/components/common/lnfiniteScroll';
+import {Notifications} from '@/types/getMynotifications';
+import {deleteMynotifications} from '@/service/api/mynotifications/deleteMyNotifications.api';
+import {CustomInfiniteData, getMynotifications} from '@/service/api/mynotifications/getMynotifications.api';
+import getInitialDevice from '@/utils/initial-device';
 import CloseIcon from '@/public/icon/ic_close_black.svg';
 import NotiBlueIcon from '@/public/icon/ic_noti_blue.svg';
 import NotiRedIcon from '@/public/icon/ic_noti_red.svg';
 import CloseButton from '@/public/icon/ic_close_button.svg';
-
-import Image from 'next/image';
-import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
-import getInitialDevice from '@/utils/initial-device';
-import OverlayContainer from '@/components/common/modal/overlay-container';
-import InfiniteScroll from '@/components/common/lnfiniteScroll';
-import {CustomInfiniteData, getMynotifications} from '@/service/api/mynotifications/getMynotifications.api';
-import {Notifications} from '@/types/getMynotifications';
-import {deleteMynotifications} from '@/service/api/mynotifications/deleteMyNotifications.api';
-import {QueryFunctionContext, useMutation, useQueryClient} from '@tanstack/react-query';
 
 interface NotificationProps {
   onClose: () => void;

--- a/components/myactivities/myactivities.tsx
+++ b/components/myactivities/myactivities.tsx
@@ -11,6 +11,7 @@ import InfiniteScroll from '@/components/common/lnfiniteScroll';
 import ActivitiesRegister from './activities-register';
 import ActivitiesModify from './activities-modify';
 import ActivitiesCard from './activities-card';
+import getInitialDevice from '@/utils/initial-device';
 import {getActivitiesList} from '@/service/api/myactivities/getActivities';
 import {patchActivities} from '@/service/api/myactivities/patchActivities.api';
 import {deleteActivities} from '@/service/api/myactivities/deleteActivities.api';
@@ -21,6 +22,7 @@ import NonDataPage from './non-data';
 import closeButton from '@/public/icon/ic_close_button.svg';
 
 type ContentType = 'manage' | 'register' | 'modify' | 'delete';
+type InitialDevice = 'mobile' | 'desktop' | 'tablet';
 
 interface MyActivitiesProps {
   contentType: ContentType;
@@ -36,6 +38,7 @@ export default function MyActivities({contentType}: MyActivitiesProps) {
   const [isValid, setIsValid] = useState(false);
   const [isValidModify, setIsValidModify] = useState(false);
   const [modifyId, setModifyId] = useState(0);
+  const [device, setDevice] = useState<InitialDevice>('mobile');
   const queryClient = useQueryClient();
 
   const postActivitiesMutation = useMutation({
@@ -160,7 +163,11 @@ export default function MyActivities({contentType}: MyActivitiesProps) {
 
   const handleClose = () => {
     setIsOpen(false);
-    updateQueryParams({type: 'manage'});
+    if (device === 'mobile') {
+      router.push('/mypage/treatReservation?modal=true');
+    } else {
+      router.push('/mypage/treatReservation');
+    }
   };
 
   useEffect(() => {
@@ -168,6 +175,11 @@ export default function MyActivities({contentType}: MyActivitiesProps) {
       setContent(contentType);
     }
   }, [contentType, content]);
+
+  useEffect(() => {
+    const getDeviceType = getInitialDevice() as InitialDevice;
+    setDevice(getDeviceType);
+  }, [device]);
 
   return (
     <>

--- a/components/myactivities/myactivities.tsx
+++ b/components/myactivities/myactivities.tsx
@@ -259,7 +259,10 @@ export default function MyActivities({contentType}: MyActivitiesProps) {
         </div>
       </div>
       {isOpen && (
-        <Modal message={`체험 ${content === 'modify' ? '수정' : content === 'register' ? '등록' : '삭제'}이 완료되었습니다`} onClose={handleClose} />
+        <Modal
+          message={`체험 ${content === 'modify' ? '수정이' : content === 'register' ? '등록이' : '삭제가'} 완료되었습니다`}
+          onClose={handleClose}
+        />
       )}
       {isOpenError && <Modal message={errorMessege} onClose={() => setIsOpenError(false)}></Modal>}
     </>

--- a/components/myactivities/time-list.tsx
+++ b/components/myactivities/time-list.tsx
@@ -137,6 +137,15 @@ export default function TimeList({type}: {type: 'register' | 'modify'}) {
     }
   };
 
+  useEffect(() => {
+    if (isWeeklyRepeat && weekCount > 0) {
+      const dates = generateDatesForWeeks(weekCount);
+      setValue('schedules', dates);
+    } else {
+      setValue('schedules', [{date: '', startTime: '09:00', endTime: '18:00'}]);
+    }
+  }, [isWeeklyRepeat, weekCount, setValue]);
+
   const renderDateField = (label: string, name: string, index: number) => {
     return (
       <div>
@@ -191,15 +200,6 @@ export default function TimeList({type}: {type: 'register' | 'modify'}) {
     );
   };
 
-  useEffect(() => {
-    if (isWeeklyRepeat && weekCount > 0) {
-      const dates = generateDatesForWeeks(weekCount);
-      setValue('schedules', dates);
-    } else {
-      setValue('schedules', [{date: '', startTime: '09:00', endTime: '18:00'}]);
-    }
-  }, [isWeeklyRepeat, weekCount, setValue]);
-
   return (
     <div className="mb-4">
       <div className="flex-col items-center justify-between tablet:flex tablet:flex-row">
@@ -234,52 +234,73 @@ export default function TimeList({type}: {type: 'register' | 'modify'}) {
           </div>
         )}
       </div>
-      <>
-        <div className={` ${isWeeklyRepeat ? 'max-h-[500px] overflow-y-auto' : ''}`}>
-          {fields.map((row, index) => (
-            <div key={row.id} className="mb-4">
-              <div className="grid max-w-full grid-cols-[minmax(150px,1fr),auto,auto,auto] gap-1 pc:grid-cols-[1fr,auto,auto,auto] pc:gap-4">
-                {/* 날짜 필드 */}
-                {renderDateField('날짜', `schedules.${index}.date`, index)}
+      <div className="mb-4">
+        {fields[0] && (
+          <div key={fields[0].id} className="mb-4">
+            <div className="grid max-w-full grid-cols-[minmax(150px,1fr),auto,auto,auto] gap-1 pc:grid-cols-[1fr,auto,auto,auto] pc:gap-4">
+              {/* 날짜 필드 */}
+              {renderDateField('날짜', `schedules.0.date`, 0)}
 
-                {/* 시작 시간 필드 */}
-                {renderSelectField('시작 시간', `schedules.${index}.startTime`, index, {label: '09:00'})}
+              {/* 시작 시간 필드 */}
+              {renderSelectField('시작 시간', `schedules.0.startTime`, 0, {label: '09:00'})}
 
-                {/* 종료 시간 필드 */}
-                {renderSelectField('종료 시간', `schedules.${index}.endTime`, index, {label: '18:00'})}
+              {/* 종료 시간 필드 */}
+              {renderSelectField('종료 시간', `schedules.0.endTime`, 0, {label: '18:00'})}
 
-                <div
-                  className={`relative h-16 w-16 cursor-pointer ${index === 0 ? 'green-button-hover mt-26pxr' : ''}`}
-                  onClick={() => (index === 0 ? handleAddRow() : handleMinusRow(index, 'fields'))}
-                >
-                  <Image src={index === 0 ? plusBtn : minusBtn} alt={index === 0 ? 'Add row' : 'Remove row'} fill />
-                </div>
+              <div className="relative mt-26pxr h-16 w-16 cursor-pointer" onClick={handleAddRow}>
+                <Image src={plusBtn} alt="Add row" fill />
               </div>
-
-              {Array.isArray(errors.schedules) && errors.schedules[index]?.date?.message && (
-                <span className="text-sm text-red-500">{(errors.schedules as ScheduleError[])[index]?.date?.message}</span>
-              )}
-              {index === 0 && <hr className="mt-4"></hr>}
             </div>
-          ))}
-        </div>
-      </>
+
+            {Array.isArray(errors.schedules) && errors.schedules[0]?.date?.message && (
+              <span className="text-sm text-red-500">{(errors.schedules as ScheduleError[])[0]?.date?.message}</span>
+            )}
+            <hr className="mt-4" />
+          </div>
+        )}
+
+        {fields.length > 1 && (
+          <div className="max-h-[500px] overflow-y-auto">
+            {fields.slice(1).map((row, index) => (
+              <div key={row.id} className="mb-4">
+                <div className="grid max-w-full grid-cols-[minmax(150px,1fr),auto,auto,auto] gap-1 pc:grid-cols-[1fr,auto,auto,auto] pc:gap-4">
+                  {/* 날짜 필드 */}
+                  {renderDateField('날짜', `schedules.${index + 1}.date`, index + 1)}
+
+                  {/* 시작 시간 필드 */}
+                  {renderSelectField('시작 시간', `schedules.${index + 1}.startTime`, index + 1, {label: '09:00'})}
+
+                  {/* 종료 시간 필드 */}
+                  {renderSelectField('종료 시간', `schedules.${index + 1}.endTime`, index + 1, {label: '18:00'})}
+
+                  <div className="relative h-16 w-16 cursor-pointer" onClick={() => handleMinusRow(index + 1, 'fields')}>
+                    <Image src={minusBtn} alt="Remove row" fill />
+                  </div>
+                </div>
+
+                {Array.isArray(errors.schedules) && errors.schedules[index + 1]?.date?.message && (
+                  <span className="text-sm text-red-500">{(errors.schedules as ScheduleError[])[index + 1]?.date?.message}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       {/* 수정시 */}
       {type === 'modify' && modifyFields.length !== 0 && (
         <>
+          <hr className="my-4" />
+          <label className="text-xl font-medium text-gray-800">추가</label>
           {modifyFields.map((row, index) => (
             <div key={row.id} className="mb-4">
-              <div className="grid grid-cols-[1fr,auto,auto,auto] gap-1 pc:grid-cols-[1fr,auto,auto,auto] pc:gap-4">
+              <div className="grid grid-cols-[minmax(150px,1fr),auto,auto,auto] gap-1 pc:grid-cols-[1fr,auto,auto,auto] pc:gap-4">
                 {/* 날짜 필드 */}
                 {renderDateField('날짜', `schedulesToAdd.${index}.date`, index)}
-
                 {/* 시작 시간 필드 */}
                 {renderSelectField('시작 시간', `schedulesToAdd.${index}.startTime`, index, {label: '09:00'})}
-
                 {/* 종료 시간 필드 */}
                 {renderSelectField('종료 시간', `schedulesToAdd.${index}.endTime`, index, {label: '18:00'})}
-
                 <div className="relative h-16 w-16 cursor-pointer" onClick={() => handleMinusRow(index, 'modifyFields')}>
                   <Image src={minusBtn} alt="Remove row" fill />
                 </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

ex) #180 

## 📝작업 내용

1. 버그사항 알림내역 css 수정
2. 수정일정 scroll 및 편한 ui 제공
3. import 정렬 안한부분 수정
4. 수정시 관리페이지로이동

이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷스크린샷 (선택)
<img width="543" alt="스크린샷 2025-02-19 오후 5 44 02" src="https://github.com/user-attachments/assets/6679fc10-d575-4579-8e54-3832a2c5499d" />

## 💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
2. 플러스 버튼을 상단에 고정
수정하기 데이터가 많을 시 스크롤추가

이두가지 부분 위주로 수정하였습니다.
