### PR TITLE
[QA 수정] 예약 현황 / 내역 관련

### DIFF
--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -2,10 +2,12 @@
 import React from 'react';
 import {useSearchParams} from 'next/navigation';
 import OverlayContainer from '@/components/common/modal/overlay-container';
+import DisableScroll from '@/utils/disable-scroll';
 
 export default function MyPageLayout({side, menu}: {side: React.ReactNode; menu: React.ReactNode}) {
   const searchParams = useSearchParams();
   const isModalOpen = searchParams.get('modal') === 'true';
+  DisableScroll(isModalOpen);
   return (
     <>
       {/* pc, 태블릿 */}

--- a/components/common/pagenation.tsx
+++ b/components/common/pagenation.tsx
@@ -96,7 +96,7 @@ function Pagenation({page, size, showItemCount, onChange}: PagenationType) {
       <Button
         key={'prevBtn'}
         className={
-          'relative h-40pxr w-40pxr flex-row items-center justify-center gap-10pxr rounded-2xl border border-solid border-gray-500 bg-white p-0 dark:bg-slate-200/80 pc:h-55pxr pc:w-55pxr'
+          'relative h-40pxr w-40pxr flex-row items-center justify-center gap-10pxr rounded-2xl border border-solid border-gray-500 bg-white p-0 pc:h-55pxr pc:w-55pxr dark:bg-slate-200/80'
         }
         onClick={handlePrevPage}
       >
@@ -122,7 +122,7 @@ function Pagenation({page, size, showItemCount, onChange}: PagenationType) {
       <Button
         key={'nextBtn'}
         className={
-          'relative h-40pxr w-40pxr flex-row items-center justify-center gap-10pxr rounded-2xl border border-solid border-gray-500 bg-white p-0 dark:bg-slate-200/80 pc:h-55pxr pc:w-55pxr'
+          'relative h-40pxr w-40pxr flex-row items-center justify-center gap-10pxr rounded-2xl border border-solid border-gray-500 bg-white p-0 pc:h-55pxr pc:w-55pxr dark:bg-slate-200/80'
         }
         onClick={handleNextPage}
       >

--- a/components/main/entire-list.tsx
+++ b/components/main/entire-list.tsx
@@ -51,7 +51,7 @@ export default function EntireList({activeCategory, selectedSort}: EntireListPro
   if (isEntireLoading) {
     return (
       <section className="mb-24pxr mt-24pxr flex w-full max-w-[75rem] flex-col justify-center gap-24pxr tablet:mt-35pxr tablet:gap-32pxr">
-        <h2 className="text-[1.125rem]/[1.313rem] font-bold text-black-100 tablet:text-3xl dark:text-gray-500">🥽 모든 체험</h2>
+        <h2 className="text-[1.125rem]/[1.313rem] font-bold text-black-100 dark:text-gray-500 tablet:text-3xl">🥽 모든 체험</h2>
         <div className="flex min-h-28 items-center justify-center">
           <ScaleLoader />
         </div>
@@ -61,10 +61,10 @@ export default function EntireList({activeCategory, selectedSort}: EntireListPro
 
   return (
     <section className="mb-24pxr mt-24pxr flex w-full max-w-[75rem] flex-col items-start justify-center gap-24pxr tablet:mt-35pxr tablet:gap-32pxr">
-      <h2 className="text-[1.125rem]/[1.313rem] font-bold text-black-100 tablet:text-3xl dark:text-gray-500">🥽 모든 체험</h2>
+      <h2 className="text-[1.125rem]/[1.313rem] font-bold text-black-100 dark:text-gray-500 tablet:text-3xl">🥽 모든 체험</h2>
       <EntireCard data={entireActivities} />
       <div className="mx-auto">
-        {entireActivities && <Pagenation page={page} size={entireActivities?.totalCount} showItemCount={pageSize} onChange={handlePageChange} />}
+        <Pagenation page={page} size={entireActivities?.totalCount} showItemCount={pageSize} onChange={handlePageChange} />
       </div>
     </section>
   );

--- a/components/main/popular-card.tsx
+++ b/components/main/popular-card.tsx
@@ -21,15 +21,28 @@ interface PopularCardProps {
 export default function PopularCard({data, fetchNextpage, hasNextPage}: PopularCardProps) {
   const [scrollX, setScrollX] = useLocalStorage('places_list_scroll', 0);
   const [swiperInstance, setSwiperInstance] = useState<SwiperType | null>(null);
+  const [isBeginning, setIsBeginning] = useState(true);
+  const [isEnd, setIsEnd] = useState(false);
   const router = useRouter();
 
   const onSwiper = (swiper: SwiperType) => {
     setSwiperInstance(swiper);
+    setIsBeginning(swiper.isBeginning);
+    setIsEnd(swiper.isEnd);
   };
 
-  const onSlideChange = () => {
-    if (swiperInstance) {
-      setScrollX(swiperInstance.realIndex);
+  const onSlideChange = (swiper: SwiperType) => {
+    setScrollX(swiper.realIndex);
+  };
+
+  const onSlideChangeTransitionEnd = (swiper: SwiperType) => {
+    setIsBeginning(swiper.isBeginning);
+    setIsEnd(swiper.isEnd);
+  };
+
+  const handleReachEnd = () => {
+    if (hasNextPage) {
+      fetchNextpage();
     }
   };
 
@@ -39,23 +52,34 @@ export default function PopularCard({data, fetchNextpage, hasNextPage}: PopularC
     }
   }, [swiperInstance, scrollX]);
 
-  const handleReachEnd = () => {
-    if (hasNextPage) {
-      fetchNextpage();
+  useEffect(() => {
+    if (swiperInstance && hasNextPage) {
+      setIsEnd(false);
     }
-  };
+  }, [data, swiperInstance, hasNextPage]);
 
   return (
     <>
       <div className="relative flex w-full items-center justify-between px-4 tablet:px-6 pc:px-0">
         <h2 className="text-[1.125rem]/[1.313rem] font-bold text-black-100 tablet:text-[2.25rem]/[2.625rem] dark:text-gray-500">🔥 인기 체험</h2>
         <div className="absolute right-9 hidden pc:flex pc:items-center pc:gap-3">
-          <button className="font-medium !text-gray-800" onClick={() => swiperInstance?.slidePrev()}>
+          {/* 왼쪽 버튼 */}
+          <button
+            className={`cursor-pointer font-medium !text-gray-800 ${isBeginning ? 'cursor-not-allowed opacity-50' : ''}`}
+            onClick={() => swiperInstance?.slidePrev()}
+            disabled={isBeginning}
+          >
             <div className="relative h-9 w-9">
               <Image src={leftButton} alt="슬라이드 좌측 버튼" fill className="absolute" />
             </div>
           </button>
-          <button className="font-medium !text-gray-800" onClick={() => swiperInstance?.slideNext()}>
+
+          {/* 오른쪽 버튼 */}
+          <button
+            className={`cursor-pointer font-medium !text-gray-800 ${isEnd ? 'cursor-not-allowed opacity-50' : ''}`}
+            onClick={() => swiperInstance?.slideNext()}
+            disabled={isEnd}
+          >
             <div className="relative h-9 w-9">
               <Image src={rightButton} alt="슬라이드 우측 버튼" fill className="absolute" />
             </div>
@@ -69,6 +93,7 @@ export default function PopularCard({data, fetchNextpage, hasNextPage}: PopularC
           modules={[Navigation]}
           onSwiper={onSwiper}
           onSlideChange={onSlideChange}
+          onSlideChangeTransitionEnd={onSlideChangeTransitionEnd}
           onReachEnd={handleReachEnd}
           breakpoints={{
             374: {slidesPerView: 1.5, spaceBetween: 8},
@@ -102,8 +127,8 @@ export default function PopularCard({data, fetchNextpage, hasNextPage}: PopularC
                     sizes="(max-width: 744px) 186px, (max-width: 1199px) 384px, 50vw"
                   />
                 </div>
-                {/* 어두운 오버레이 추가 */}
-                <div className="absolute inset-0 rounded-3xl bg-black-50 opacity-20"></div> {/* 어두운 오버레이 */}
+                {/* 어두운 오버레이 */}
+                <div className="absolute inset-0 rounded-3xl bg-black-50 opacity-20"></div>
                 {/* 카드 내용 */}
                 <div className="relative z-10 p-4 text-white tablet:p-6">
                   <div className="flex items-center gap-2">

--- a/components/main/sort-select.tsx
+++ b/components/main/sort-select.tsx
@@ -10,8 +10,8 @@ interface CustomSelectProps {
 
 export default function SortSelect({selectedSort, onSelectedSort}: CustomSelectProps) {
   const options = [
-    {value: 'price_asc', label: '가격이 낮은 순'},
-    {value: 'price_desc', label: '가격이 높은 순'},
+    {value: 'price_asc', label: '가격 낮은 순'},
+    {value: 'price_desc', label: '가격 높은 순'},
   ];
   const [isOpen, setIsOpen] = useState(false);
 
@@ -25,7 +25,7 @@ export default function SortSelect({selectedSort, onSelectedSort}: CustomSelectP
   return (
     <div
       onClick={() => setIsOpen(prev => !prev)}
-      className="relative h-41pxr w-90pxr min-w-[90px] cursor-pointer rounded-2xl border border-nomad-black bg-white px-2 py-2 tablet:h-53pxr tablet:w-120pxr tablet:px-5 tablet:py-4 pc:w-127pxr dark:border-slate-600 dark:bg-slate-900/10"
+      className="relative h-41pxr w-90pxr min-w-[90px] cursor-pointer rounded-2xl border border-nomad-black bg-white px-2 py-2 tablet:h-53pxr tablet:w-123pxr tablet:px-5 tablet:py-4 pc:w-127pxr dark:border-slate-600 dark:bg-slate-900/10"
     >
       <div className="flex items-center justify-center gap-1 rounded-md tablet:justify-between">
         <span className="overflow-hidden text-ellipsis whitespace-nowrap text-md font-medium text-green-100 tablet:text-2lg dark:text-slate-600">
@@ -41,7 +41,7 @@ export default function SortSelect({selectedSort, onSelectedSort}: CustomSelectP
           {options.map(option => (
             <li
               key={option.value}
-              className="no-scrollbar w-[90px] border-collapse cursor-pointer border-t border-gray-200 px-5pxr py-18pxr text-md font-medium text-gray-800 hover:bg-green-50 hover:text-nomad-black tablet:w-[120px] tablet:text-2lg pc:w-127pxr dark:border-slate-500 dark:bg-slate-400"
+              className="no-scrollbar w-[90px] border-collapse cursor-pointer border-t border-gray-200 px-5pxr py-18pxr text-center text-md font-medium text-gray-800 hover:bg-green-50 hover:text-nomad-black tablet:w-[120px] tablet:text-2lg pc:w-127pxr dark:border-slate-500 dark:bg-slate-400"
               onClick={() => handleSelect(option.value as 'price_asc' | 'price_desc' | 'most_reviewed' | 'latest')}
             >
               {option.label}

--- a/components/myactivities/myactivities.tsx
+++ b/components/myactivities/myactivities.tsx
@@ -259,7 +259,10 @@ export default function MyActivities({contentType}: MyActivitiesProps) {
         </div>
       </div>
       {isOpen && (
-        <Modal message={`체험 ${content === 'modify' ? '수정' : content === 'register' ? '등록' : '삭제'}이 완료되었습니다`} onClose={handleClose} />
+        <Modal
+          message={`체험 ${content === 'modify' ? '수정이' : content === 'register' ? '등록이' : '삭제가'} 완료되었습니다`}
+          onClose={handleClose}
+        />
       )}
       {isOpenError && <Modal message={errorMessege} onClose={() => setIsOpenError(false)}></Modal>}
     </>

--- a/components/reservation-calendar/activity-selector.tsx
+++ b/components/reservation-calendar/activity-selector.tsx
@@ -14,7 +14,6 @@ export default function ActivitySelector({
   onToggle: () => void;
   onSelect: (activity: {title: string; id: number}) => void;
 }) {
-  console.log(activities);
   return (
     <div className="relative mb-8">
       <button onClick={onToggle} className="relative h-14 min-h-14 w-full cursor-pointer rounded border border-gray-700 px-5 text-left">

--- a/components/reservation-list/reservation-card.tsx
+++ b/components/reservation-list/reservation-card.tsx
@@ -29,7 +29,6 @@ interface ReservationCardProps {
 }
 
 export default function ReservationCard({reservation, onButtonClick}: ReservationCardProps) {
-  console.log(reservation.reviewSubmitted);
   return (
     <div className="flex h-32 w-full items-center rounded-3xl bg-white shadow-sidenavi-box tablet:h-156pxr pc:h-204pxr">
       <div className="relative aspect-[1/1] h-32 w-32 flex-shrink tablet:h-156pxr tablet:w-156pxr pc:h-204pxr pc:w-204pxr">

--- a/components/reservation-list/reservation-card.tsx
+++ b/components/reservation-list/reservation-card.tsx
@@ -19,6 +19,8 @@ export const buttonStyleByStatus: Record<string, string> = {
     'white-button-hover w-80pxr h-8 py-1 px-2 font-bold text-md text-nomad-black tablet:text-lg tablet:w-112pxr tablet:h-40pxr tablet:px-3 tablet:py-2 bg-white border border-nomad-black rounded-md',
   completed:
     'w-80pxr h-8 py-1 px-2 font-bold text-md text-white tablet:text-lg tablet:w-112pxr tablet:h-40pxr tablet:px-3 tablet:py-2 bg-nomad-black rounded-md nomad-button-hover',
+  submitted:
+    'w-80pxr h-8 py-1 px-2 font-bold text-md text-white tablet:text-lg tablet:w-112pxr tablet:h-40pxr tablet:px-3 tablet:py-2 bg-gray-700 rounded-md pointer-events-none ',
 };
 
 interface ReservationCardProps {
@@ -27,6 +29,7 @@ interface ReservationCardProps {
 }
 
 export default function ReservationCard({reservation, onButtonClick}: ReservationCardProps) {
+  console.log(reservation.reviewSubmitted);
   return (
     <div className="flex h-32 w-full items-center rounded-3xl bg-white shadow-sidenavi-box tablet:h-156pxr pc:h-204pxr">
       <div className="relative aspect-[1/1] h-32 w-32 flex-shrink tablet:h-156pxr tablet:w-156pxr pc:h-204pxr pc:w-204pxr">
@@ -48,8 +51,12 @@ export default function ReservationCard({reservation, onButtonClick}: Reservatio
         </div>
         <div className="flex items-center justify-between">
           <p className="text-lg font-medium text-black-100 tablet:text-xl">￦{FormattedPrice(reservation.totalPrice)}</p>
-          <Button onClick={() => onButtonClick(`${reservation.status}`, reservation.id)} className={`${buttonStyleByStatus[reservation.status]}`}>
-            {buttonByStatus[reservation.status]}
+          <Button
+            disabled={reservation.reviewSubmitted}
+            onClick={() => onButtonClick(`${reservation.status}`, reservation.id)}
+            className={`${reservation.reviewSubmitted ? buttonStyleByStatus['submitted'] : buttonStyleByStatus[reservation.status]}`}
+          >
+            {reservation.reviewSubmitted ? '작성 완료' : buttonByStatus[reservation.status]}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## #️⃣연관된 이슈
#179 

## 📝작업 내용
 - 예약 내역(모바일) 스크롤 2개?? -> 해결
 - 리뷰 작성한 체험의 경우 버튼 막기 -> 해결
 - 인기 체험 네비게이션 버튼 opacity 및 disabled 적용
 - 모든 체험 셀렉 박스 가격 낮...., 가격 높.... 까지 표시

## 📷스크린샷
![스크린샷 2025-02-20 002703](https://github.com/user-attachments/assets/ae63c8df-0a7b-4ed2-952f-84e6aaf20c3d)
